### PR TITLE
Backup https cert content to gitlab variables

### DIFF
--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -7,76 +7,63 @@ set -u
 # Load .env se we can access CSV_DIR
 source "./.env"
 
-# Path to the certs and store the cert content
-FULLCHAIN_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/fullchain.pem)
-PRIVATE_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/privkey.pem)
-CHAIN_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/chain.pem)
+# Path to the certs
+FULLCHAIN_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/fullchain.pem
+PRIVATE_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/privkey.pem
+CHAIN_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/chain.pem
 
 # Backup the fullchain cert to GITLAB CI environment variable and get the http code
 http_code_fullchain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "key": "'"$GIGADB_ENV"'_tlsauth_fullchain",
-        "value": "'"$(echo $FULLCHAIN_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "key=${GIGADB_ENV}_tlsauth_fullchain" \
+    --form "value=$(cat $FULLCHAIN_PEM)"
     )
 
+# Update fullchain cert content if it has been created already
 if [[ $http_code_fullchain -eq 400 ]];then
   curl --include --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "value": "'"$(echo $FULLCHAIN_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "value=$(cat $FULLCHAIN_PEM)"
 fi
-# Backup the private key cert to GITLAB CI environment variable and get the http code
+
+# Backup the private cert to GITLAB CI environment variable and get the http code
 http_code_private=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "key": "'"$GIGADB_ENV"'_tlsauth_private",
-        "value": "'"$(echo $PRIVATE_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "key=${GIGADB_ENV}_tlsauth_private" \
+    --form "value=$(cat $PRIVATE_PEM)"
     )
 
+# Update the private cert content if it has been created already
 if [[ $http_code_private -eq 400 ]];then
   curl --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "value": "'"$(echo $PRIVATE_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "value=$(cat $PRIVATE_PEM)"
 fi
+
 # Backup the chain cert to GITLAB CI environment variable and get the http code
 http_code_chain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "key": "'"$GIGADB_ENV"'_tlsauth_fullchain",
-        "value": "'"$(echo $CHAIN_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "key=${GIGADB_ENV}_tlsauth_chain" \
+    --form "value=$(cat $CHAIN_PEM)"
     )
 
+# Update the chain cert content if it has been created already
 if [[ $http_code_chain -eq 400 ]];then
   curl --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --header "content-type: application/json" \
-    --data '{
-        "value": "'"$(echo $CHAIN_PEM)"'",
-        "environment_scope": "'"$GIGADB_ENV"'"
-      }'
+    --form "environment_scope=${GIGADB_ENV}" \
+    --form "value=$(cat $CHAIN_PEM)"
 fi
 
 # docker-compose executable

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -12,60 +12,6 @@ FULLCHAIN_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
 PRIVATE_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem
 CHAIN_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
 
-# Backup the fullchain cert to GITLAB CI environment variable and get the http code
-http_code_fullchain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request POST --url "$PROJECT_VARIABLES_URL" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "key=${GIGADB_ENV}_tlsauth_fullchain" \
-    --form "value=$(cat $FULLCHAIN_PEM)"
-    )
-
-# Update fullchain cert content if it has been created already
-if [[ $http_code_fullchain -eq 400 ]];then
-  curl --include --include --show-error --silent --output /dev/null  \
-    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "value=$(cat $FULLCHAIN_PEM)"
-fi
-
-# Backup the private cert to GITLAB CI environment variable and get the http code
-http_code_private=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request POST --url "$PROJECT_VARIABLES_URL" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "key=${GIGADB_ENV}_tlsauth_private" \
-    --form "value=$(cat $PRIVATE_PEM)"
-    )
-
-# Update the private cert content if it has been created already
-if [[ $http_code_private -eq 400 ]];then
-  curl --include --show-error --silent --output /dev/null  \
-    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "value=$(cat $PRIVATE_PEM)"
-fi
-
-# Backup the chain cert to GITLAB CI environment variable and get the http code
-http_code_chain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request POST --url "$PROJECT_VARIABLES_URL" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "key=${GIGADB_ENV}_tlsauth_chain" \
-    --form "value=$(cat $CHAIN_PEM)"
-    )
-
-# Update the chain cert content if it has been created already
-if [[ $http_code_chain -eq 400 ]];then
-  curl --include --show-error --silent --output /dev/null  \
-    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
-    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=$GIGADB_ENV" \
-    --form "value=$(cat $CHAIN_PEM)"
-fi
-
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
 	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
@@ -79,7 +25,85 @@ $DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAM
 if [[ $? -eq 0 ]];then
 	echo "Renewing the certificate for $REMOTE_HOSTNAME"
 	$DOCKER_COMPOSE run --rm certbot renew
+	echo "Backup the fullchain cert to gitlab variable"
+  	curl --show-error --silent --output /dev/null  \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "value=$(cat $FULLCHAIN_PEM)"
+
+  echo "Backup the private cert to gitlab variable"
+    curl --show-error --silent --output /dev/null  \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "value=$(cat $PRIVATE_PEM)"
+
+  echo "Backup the chain cert to gitlab variable"
+    curl --show-error --silent --output /dev/null  \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "value=$(cat $CHAIN_PEM)"
 else
-	echo "Creating the certificate for $REMOTE_HOSTNAME"
-	$DOCKER_COMPOSE run --rm certbot certonly -d $REMOTE_HOSTNAME
+  echo "Certs do not exist in the filesystem"
+  echo "To see if could be found in gitlab"
+  http_code_get_fullchain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+  )
+  http_code_get_private=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+  )
+  http_code_get_chain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+  )
+
+  if [[ $http_code_get_fullchain -eq 200 && $http_code_get_private -eq 200 && $http_code_get_chain -eq 200 ]];then
+    echo "Certs fullchain, privkey and chain could be found in gitlab"
+    echo "Get fullchain cert from gitlab"
+    curl --show-error --silent \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
+
+    echo "Get private cert from gitlab"
+    curl --show-error --silent \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem
+
+    echo "Get chain cert from gitlab"
+    curl --show-error --silent \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
+  fi
+
+  if [[ $http_code_get_fullchain -eq 404 || $http_code_get_private -eq 404 || $http_code_get_chain -eq 404 ]];then
+    echo "Not all certs found in gitlab, creating the certificate for $REMOTE_HOSTNAME!"
+	  $DOCKER_COMPOSE run --rm certbot certonly -d $REMOTE_HOSTNAME
+	  echo "Fullchain cert created and put it into gitlab"
+    curl --show-error --silent --output /dev/null \
+      --request POST --url "$PROJECT_VARIABLES_URL" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "key=${GIGADB_ENV}_tlsauth_fullchain" \
+      --form "value=$(cat $FULLCHAIN_PEM)"
+
+    echo "Private cert created and put it into gitlab"
+    curl --show-error --silent --output /dev/null \
+      --request POST --url "$PROJECT_VARIABLES_URL" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "key=${GIGADB_ENV}_tlsauth_private" \
+      --form "value=$(cat $PRIVATE_PEM)"
+
+    echo "Chain cert created and put it into gitlab"
+    curl --show-error --silent --output /dev/null \
+      --request POST --url "$PROJECT_VARIABLES_URL" \
+      --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+      --form "environment_scope=$GIGADB_ENV" \
+      --form "key=${GIGADB_ENV}_tlsauth_chain" \
+      --form "value=$(cat $CHAIN_PEM)"
+  fi
 fi

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -8,15 +8,15 @@ set -u
 source "./.env"
 
 # Path to the certs
-FULLCHAIN_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/fullchain.pem
-PRIVATE_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/privkey.pem
-CHAIN_PEM=/etc/letsencrypt/live/$REMOTE_HOSTNAME/chain.pem
+FULLCHAIN_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
+PRIVATE_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem
+CHAIN_PEM=/etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
 
 # Backup the fullchain cert to GITLAB CI environment variable and get the http code
 http_code_fullchain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "key=${GIGADB_ENV}_tlsauth_fullchain" \
     --form "value=$(cat $FULLCHAIN_PEM)"
     )
@@ -26,7 +26,7 @@ if [[ $http_code_fullchain -eq 400 ]];then
   curl --include --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "value=$(cat $FULLCHAIN_PEM)"
 fi
 
@@ -34,7 +34,7 @@ fi
 http_code_private=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "key=${GIGADB_ENV}_tlsauth_private" \
     --form "value=$(cat $PRIVATE_PEM)"
     )
@@ -44,7 +44,7 @@ if [[ $http_code_private -eq 400 ]];then
   curl --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "value=$(cat $PRIVATE_PEM)"
 fi
 
@@ -52,7 +52,7 @@ fi
 http_code_chain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
     --request POST --url "$PROJECT_VARIABLES_URL" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "key=${GIGADB_ENV}_tlsauth_chain" \
     --form "value=$(cat $CHAIN_PEM)"
     )
@@ -62,7 +62,7 @@ if [[ $http_code_chain -eq 400 ]];then
   curl --include --show-error --silent --output /dev/null  \
     --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
-    --form "environment_scope=${GIGADB_ENV}" \
+    --form "environment_scope=$GIGADB_ENV" \
     --form "value=$(cat $CHAIN_PEM)"
 fi
 
@@ -74,7 +74,7 @@ else
 fi
 
 echo "Checking whether the certificate exists"
-$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/live/$REMOTE_HOSTNAME/fullchain.pem
+$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
 
 if [[ $? -eq 0 ]];then
 	echo "Renewing the certificate for $REMOTE_HOSTNAME"

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -20,7 +20,9 @@ else
 fi
 
 echo "Checking whether the certificate exists"
-$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
+$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem && \
+$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem && \
+$DOCKER_COMPOSE exec -T web test -f /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
 
 if [[ $? -eq 0 ]];then
 	echo "Renewing the certificate for $REMOTE_HOSTNAME"

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -29,21 +29,21 @@ if [[ $? -eq 0 ]];then
 	$DOCKER_COMPOSE run --rm certbot renew
 	echo "Backup the fullchain cert to gitlab variable"
   	curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/tls_fullchain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $FULLCHAIN_PEM)"
 
   echo "Backup the private cert to gitlab variable"
     curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/tls_privkey_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $PRIVATE_PEM)"
 
   echo "Backup the chain cert to gitlab variable"
     curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/tls_chain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $CHAIN_PEM)"
@@ -51,15 +51,15 @@ else
   echo "Certs do not exist in the filesystem"
   echo "To see if could be found in gitlab"
   http_code_get_fullchain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+    --request GET --url "$PROJECT_VARIABLES_URL/tls_fullchain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
   http_code_get_private=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+    --request GET --url "$PROJECT_VARIABLES_URL/tls_privkey_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
   http_code_get_chain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+    --request GET --url "$PROJECT_VARIABLES_URL/tls_chain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
 
@@ -67,17 +67,17 @@ else
     echo "Certs fullchain, privkey and chain could be found in gitlab"
     echo "Get fullchain cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request GET --url "$PROJECT_VARIABLES_URL/tls_fullchain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
 
     echo "Get private cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request GET --url "$PROJECT_VARIABLES_URL/tls_privkey_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem
 
     echo "Get chain cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
+      --request GET --url "$PROJECT_VARIABLES_URL/tls_chain_pem?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
   fi
 
@@ -89,7 +89,7 @@ else
       --request POST --url "$PROJECT_VARIABLES_URL" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
-      --form "key=${GIGADB_ENV}_tlsauth_fullchain" \
+      --form "key=tls_fullchain_pem" \
       --form "value=$(cat $FULLCHAIN_PEM)"
 
     echo "Private cert created and put it into gitlab"
@@ -97,7 +97,7 @@ else
       --request POST --url "$PROJECT_VARIABLES_URL" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
-      --form "key=${GIGADB_ENV}_tlsauth_private" \
+      --form "key=tls_privkey_pem" \
       --form "value=$(cat $PRIVATE_PEM)"
 
     echo "Chain cert created and put it into gitlab"
@@ -105,7 +105,7 @@ else
       --request POST --url "$PROJECT_VARIABLES_URL" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
-      --form "key=${GIGADB_ENV}_tlsauth_chain" \
+      --form "key=tls_chain_pem" \
       --form "value=$(cat $CHAIN_PEM)"
   fi
 fi

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -7,6 +7,77 @@ set -u
 # Load .env se we can access CSV_DIR
 source "./.env"
 
+# Path to the certs and store the cert content
+FULLCHAIN_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/fullchain.pem)
+PRIVATE_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/privkey.pem)
+CHAIN_PEM=$(cat /etc/letsencrypt/live/$REMOTE_HOSTNAME/chain.pem)
+
+# Backup the fullchain cert to GITLAB CI environment variable and get the http code
+http_code_fullchain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request POST --url "$PROJECT_VARIABLES_URL" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "key": "'"$GIGADB_ENV"'_tlsauth_fullchain",
+        "value": "'"$(echo $FULLCHAIN_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+    )
+
+if [[ $http_code_fullchain -eq 400 ]];then
+  curl --include --include --show-error --silent --output /dev/null  \
+    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "value": "'"$(echo $FULLCHAIN_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+fi
+# Backup the private key cert to GITLAB CI environment variable and get the http code
+http_code_private=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request POST --url "$PROJECT_VARIABLES_URL" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "key": "'"$GIGADB_ENV"'_tlsauth_private",
+        "value": "'"$(echo $PRIVATE_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+    )
+
+if [[ $http_code_private -eq 400 ]];then
+  curl --include --show-error --silent --output /dev/null  \
+    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "value": "'"$(echo $PRIVATE_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+fi
+# Backup the chain cert to GITLAB CI environment variable and get the http code
+http_code_chain=$(curl --include --show-error --silent --output /dev/null --write-out "%{http_code}" \
+    --request POST --url "$PROJECT_VARIABLES_URL" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "key": "'"$GIGADB_ENV"'_tlsauth_fullchain",
+        "value": "'"$(echo $CHAIN_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+    )
+
+if [[ $http_code_chain -eq 400 ]];then
+  curl --include --show-error --silent --output /dev/null  \
+    --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+    --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
+    --header "content-type: application/json" \
+    --data '{
+        "value": "'"$(echo $CHAIN_PEM)"'",
+        "environment_scope": "'"$GIGADB_ENV"'"
+      }'
+fi
 
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then

--- a/ops/scripts/setup_cert.sh
+++ b/ops/scripts/setup_cert.sh
@@ -29,21 +29,21 @@ if [[ $? -eq 0 ]];then
 	$DOCKER_COMPOSE run --rm certbot renew
 	echo "Backup the fullchain cert to gitlab variable"
   	curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $FULLCHAIN_PEM)"
 
   echo "Backup the private cert to gitlab variable"
     curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $PRIVATE_PEM)"
 
   echo "Backup the chain cert to gitlab variable"
     curl --show-error --silent --output /dev/null  \
-      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+      --request PUT --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
       --form "environment_scope=$GIGADB_ENV" \
       --form "value=$(cat $CHAIN_PEM)"
@@ -51,15 +51,15 @@ else
   echo "Certs do not exist in the filesystem"
   echo "To see if could be found in gitlab"
   http_code_get_fullchain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
   http_code_get_private=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
   http_code_get_chain=$(curl --show-error --silent --output /dev/null --write-out "%{http_code}" \
-    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+    --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
     --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" \
   )
 
@@ -67,17 +67,17 @@ else
     echo "Certs fullchain, privkey and chain could be found in gitlab"
     echo "Get fullchain cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain" \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_fullchain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/fullchain.pem
 
     echo "Get private cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private" \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_private?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/privkey.pem
 
     echo "Get chain cert from gitlab"
     curl --show-error --silent \
-      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain" \
+      --request GET --url "$PROJECT_VARIABLES_URL/${GIGADB_ENV}_tlsauth_chain?filter%5benvironment_scope%5d=$GIGADB_ENV" \
       --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" | jq -r ".value" > /etc/letsencrypt/$GIGADB_ENV/$REMOTE_HOSTNAME/chain.pem
   fi
 


### PR DESCRIPTION
This is PR for storing https certificate content to gitlab variables [#738](https://github.com/gigascience/gigadb-website/issues/738).

### Logic
- 1. To check for the existence of `fullchain, privkey and chain` certs in filesystems.
  - 1.1. If yes, renew all the certs and `PUT` them to gitlab variables
  - 1.2. If no,  to check if those certs exist in gitlab variables already
     - 1.2.1 If yes, get the certs from gitlab to filesystem
     - 1.2.2 If no, create new certs then `POST` them to gitlab variables

### Expected outcome
The following 3 variables will be created in gitlab and sync with those in the filesystem.

1.  tlsauth_fullchain_pem for full chain certificate.
2. tlsauth_privkey_pem for private certificate.
3. tlsauth_chain_pem for chain certificate.

The feature of [environment_scope](https://github.com/rija/gigadb-website/commit/6fc235a#) has been included.
