### PR TITLE
PR for convert production db backup to modern psql

### DIFF
--- a/sql/README.md
+++ b/sql/README.md
@@ -72,12 +72,17 @@ docker-compose run --rm updater ./yii dataset-files/download-restore-backup --la
 For a detailed usage information, please
 go to [here](https://github.com/rija/gigadb-website/tree/files-url-updater-%23629/gigadb/app/tools/files-url-updater)
 
-Then load production backup to the `PostgreSQL` using `pg_restore`, for example:
+Then go into docker environment and do the conversion using `pg_restore` and `pg_dump`, for example:
 ```bash
-pg_restore -v -U gigadb -h database -p 5432 -d gigadbv3_production /gigadb/app/tools/files-url-updater/sql/gigadbv3_$date.backup
-```
+cd /gigadb-website
+docker-compose run --rm test bash
 
-Finally, convert the database using the latest `pg_dump`, for example:
-```bash
+# Create database for the restore
+psql -h database -U gigadb -c 'create database gigadbv3_production'
+
+# Load production backup
+pg_restore -v -U gigadb -h database -p 5432 -d gigadbv3_production /gigadb/app/tools/files-url-updater/sql/gigadbv3_$date.backup
+
+# Convert the database
 pg_dump -v -U gigadb -h database -p 5432 -Fc -d gigadbv3_production -f /sql/psql-v96/gigadbv3_$date_$version.pgdmp
 ```

--- a/sql/convert_production_db_to_latest_ver.sh
+++ b/sql/convert_production_db_to_latest_ver.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+source ./.env
+source ./.secrets
+
+latest=$(date -v-1d +"%Y%m%d")
+
+# docker-compose executable
+if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
+	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
+else
+	DOCKER_COMPOSE="docker-compose"
+fi
+
+echo "Go into docker container and store the postgreSQL version"
+version=$($DOCKER_COMPOSE run --rm test bash -c "psql --version | cut -d' ' -f 3")
+
+echo "Download the production database using file-url-updater"
+cd gigadb/app/tools/files-url-updater/
+docker-compose run --rm updater ./yii dataset-files/download-restore-backup --latest --norestore
+cd ../../../../
+
+echo "Create production database for the version upgrade"
+$DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'create database gigadbv3_production'"
+
+echo "Load the production database in PostgreSQL"
+$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_restore -v -U gigadb -h database -p 5432 -d gigadbv3_production /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}.backup"
+
+echo "Dump production database"
+$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -Fc -d gigadbv3_production -f /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}_${version}.backup"
+$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -d gigadbv3_production -f /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}_${version}.sql"
+
+echo "Drop production database after conversion"
+$DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'drop database gigadbv3_production'"
+#
+if [[ -f gigadb/app/tools/files-url-updater/sql/gigadbv3_"$latest"_"$version".backup ]];then
+  echo "Finished convert production database to postgreSQL version" "$version"
+else
+  echo "No upgraded database dump found, conversion fail!"
+fi

--- a/sql/convert_production_db_to_latest_ver.sh
+++ b/sql/convert_production_db_to_latest_ver.sh
@@ -13,7 +13,7 @@ else
 fi
 
 echo "Go into docker container and store the postgreSQL version"
-version=$($DOCKER_COMPOSE run --rm test bash -c "psql --version | cut -d' ' -f 3")
+version=$($DOCKER_COMPOSE run --rm test bash -c "psql --version | cut -d' ' -f 3 | tr -d '\n'")
 
 echo "Download the production database using file-url-updater"
 cd gigadb/app/tools/files-url-updater/
@@ -27,13 +27,13 @@ echo "Load the production database in PostgreSQL"
 $DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_restore -v -U gigadb -h database -p 5432 -d gigadbv3_production /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}.backup"
 
 echo "Dump production database"
-$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -Fc -d gigadbv3_production -f /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}_${version}.backup"
-$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -d gigadbv3_production -f /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_${latest}_${version}.sql"
+#$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -d gigadbv3_production -f /var/www/sql/psql-v96/gigadbv3_${latest}_${version}.sql"
+$DOCKER_COMPOSE run --rm test bash -c "PGPASSWORD=$GIGADB_PASSWORD pg_dump -v -U gigadb -h database -p 5432 -Fc -d gigadbv3_production -f /var/www/sql/psql-v96/gigadbv3_${latest}_${version}.pgdmp"
 
 echo "Drop production database after conversion"
 $DOCKER_COMPOSE run --rm test bash -c "psql -h database -U gigadb -c 'drop database gigadbv3_production'"
-#
-if [[ -f gigadb/app/tools/files-url-updater/sql/gigadbv3_"$latest"_"$version".backup ]];then
+
+if [[ -f sql/psql-v96/gigadbv3_"$latest"_"$version".pgdmp ]];then
   echo "Finished convert production database to postgreSQL version" "$version"
 else
   echo "No upgraded database dump found, conversion fail!"


### PR DESCRIPTION
This PR is for [#731](https://github.com/gigascience/gigadb-website/issues/731)

This PR is about:
1. Download production database using `files-url-updater`.
2. Restore it using current `pg_restore` version.
3. Dump the database using current `pg_dump` version
4. Save the current version of production database to `sql/psql-v96` 