### PR TITLE
Add support for portainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ $ docker-compose run --rm test bin/behat --profile local --stop-on-failure featu
 
 ## Troubleshooting
 
+### using Portainer
+
+When working on your local dev environment, navigate to ``http://localhost:9009``.
+Portainer will give you quick access to all the details about all running container
+as well as controls to **start/stop/kill/restart/pause/resume** them.
+More importantly, you can easily acces the logs or drop into console mode by
+clicking the relevant icon next to the container.f
+
+The only pre-requisite is that a PORTAINER_BCRYPT variable is defined in the ``.env`` file.
+Look at the ``env-sample`` file for inline instructions on how to generate a correct value for 
+your chosen password.
+
+On production environment, the variable will be exposed from GitLab Group variable.
+
+### using CLI
+
 To access the services logs, use the command below:
 
 ```

--- a/ops/configuration/variables/env-sample
+++ b/ops/configuration/variables/env-sample
@@ -17,7 +17,13 @@ COMPOSE_PROJECT_NAME=deployment
 # This token allows access to the secret variables stored on GitLab.com for logins, passwords, api keys and secrets
 # required by the project. If you don't have one, generate from your user account setting on Gitlab.com.
 
-#GITLAB_PRIVATE_TOKEN=
+GITLAB_PRIVATE_TOKEN=
+
+### Portainer credentials
+# you obtain the bcrypt password by running:
+# docker run --rm httpd:2.4-alpine htpasswd -nbB admin "your-password" | cut -d ":" -f 2 | sed -e 's/\$/\\\$/g'
+
+PORTAINER_BCRYPT=
 
 ### GitLab API URLs  ####################################################################################################
 # the urls be different for each environment and forks.

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -643,6 +643,16 @@ services:
     expose:
       - "11300"
 
+  portainer:
+    image: portainer/portainer-ce
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    ports:
+      - 9009:9000
+      - 8000:8000
+    command: -H unix:///var/run/docker.sock --admin-password $PORTAINER_BCRYPT
+
   local-cert:
     build:
       context: ..
@@ -663,3 +673,4 @@ networks:
 volumes:
   le_config:
   le_webrootpath:
+  portainer_data:

--- a/ops/scripts/generate_config.sh
+++ b/ops/scripts/generate_config.sh
@@ -3,8 +3,6 @@
 # bail out upon error
 set -e
 
-# bail out if an unset variable is used
-set -u
 
 # display the lines of this script as they are executed for debugging
 #set -x
@@ -46,7 +44,7 @@ if ! [ -f  ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${FORK_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") |.key + "=" + .value' > .fork_var
 
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"
-    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | select(.key != "TLSAUTH_CERT") | select(.key != "TLSAUTH_KEY") | select(.key != "TLSAUTH_CA") | select(.key != "staging_tlsauth_ca") | select(.key != "staging_tlsauth_key") | select(.key != "staging_tlsauth_cert") | select(.key != "live_tlsauth_ca_ca") | select(.key != "live_tlsauth_ca_cert") | select(.key != "live_tlsauth_ca_key") |.key + "=" + .value' > .project_var
+    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | select(.key != "TLSAUTH_CERT") | select(.key != "TLSAUTH_KEY") | select(.key != "TLSAUTH_CA") | select(.key != "staging_tlsauth_ca") | select(.key != "staging_tlsauth_key") | select(.key != "staging_tlsauth_cert") | select(.key != "live_tlsauth_ca") | select(.key != "live_tlsauth_cert") | select(.key != "live_tlsauth_key") |.key + "=" + .value' > .project_var
     cat .group_var .fork_var .project_var > .secrets && rm .group_var && rm .fork_var && rm .project_var
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi

--- a/up.sh
+++ b/up.sh
@@ -80,3 +80,6 @@ docker-compose up -d fuw-worker gigadb-worker
 docker-compose run --rm test ./protected/yiic generatefiletypes
 docker-compose run --rm test ./protected/yiic generatefileformats
 
+
+# start the container admin UI
+docker-compose up -d portainer


### PR DESCRIPTION

Portainer is a web based control panel for docker containers, allowing easy access to logs and console and controls.

Also fix a problem where generate_config.sh will crash if there's no .secrets file.