### PR TITLE
To ensure staging and new live are not indexed by search engines

### DIFF
--- a/features/bootstrap/DatasetViewContext.php
+++ b/features/bootstrap/DatasetViewContext.php
@@ -471,4 +471,13 @@ class DatasetViewContext implements Context
         $element = $this->minkContext->getSession()->getPage()->find('css', "a[id='$arg1']" );
         $element->click();
     }
+
+    /**
+     * @Then There is a meta tag :arg1 with value :arg2
+     */
+    public function thereIsAMetaTagWithValue($arg1, $arg2)
+    {
+        $metaNode = $this->minkContext->getSession()->getPage()->find('xpath', "//meta[@name='$arg1' and @content='$arg2']");
+        PHPUnit_Framework_Assert::assertNotNull($metaNode);
+    }
 }

--- a/features/pages-not-indexed-by-search-engines.feature
+++ b/features/pages-not-indexed-by-search-engines.feature
@@ -24,4 +24,3 @@ Feature:
     Given I am not logged in to Gigadb web site
     When I go to "/dataset/100016"
     Then there is a meta tag "robots" with value "noindex, nofollow"
-

--- a/features/pages-not-indexed-by-search-engines.feature
+++ b/features/pages-not-indexed-by-search-engines.feature
@@ -12,15 +12,18 @@ Feature:
     Given I am not logged in to Gigadb web site
     When I go to "site/faq"
     Then there is a meta tag "robots" with value "noindex, nofollow"
+    And there is a meta tag "googlebot" with value "noindex, nofollow"
 
   @ok
   Scenario: Search engines cannot index and follow main page
     Given I am not logged in to Gigadb web site
     When I go to "/index.php"
     Then there is a meta tag "robots" with value "noindex, nofollow"
+    And there is a meta tag "googlebot" with value "noindex, nofollow"
 
   @ok
   Scenario: Search engines cannot index and follow dataset page
     Given I am not logged in to Gigadb web site
     When I go to "/dataset/100016"
     Then there is a meta tag "robots" with value "noindex, nofollow"
+    And there is a meta tag "googlebot" with value "noindex, nofollow"

--- a/features/pages-not-indexed-by-search-engines.feature
+++ b/features/pages-not-indexed-by-search-engines.feature
@@ -1,0 +1,27 @@
+@issue-785
+Feature:
+  As an admin
+  I do not want all search engines to recognise staging and new live GigaDB page urls
+  So that pages under development would not be released
+
+  Background:
+    Given Gigadb web site is loaded with production-like data
+
+  @ok
+  Scenario: Search engines cannot index and follow faq page
+    Given I am not logged in to Gigadb web site
+    When I go to "site/faq"
+    Then there is a meta tag "robots" with value "noindex, nofollow"
+
+  @ok
+  Scenario: Search engines cannot index and follow main page
+    Given I am not logged in to Gigadb web site
+    When I go to "/index.php"
+    Then there is a meta tag "robots" with value "noindex, nofollow"
+
+  @ok
+  Scenario: Search engines cannot index and follow dataset page
+    Given I am not logged in to Gigadb web site
+    When I go to "/dataset/100016"
+    Then there is a meta tag "robots" with value "noindex, nofollow"
+

--- a/ops/configuration/gigadb-public/robots.txt
+++ b/ops/configuration/gigadb-public/robots.txt
@@ -1,0 +1,3 @@
+# Block all web crawlers from crawling of all content
+User-agent: *
+Disallow: /

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -9,6 +9,7 @@ COPY ops/configuration/nginx-conf/enable_sites /usr/local/bin/enable_sites
 COPY css /var/www/css
 COPY docs /var/www/docs
 COPY favicon.ico /var/www/favicon.ico
+COPY robots.txt /var/www/robots.txt
 COPY fonts /var/www/fonts
 COPY images /var/www/images
 COPY index.php /var/www/index.php

--- a/ops/packaging/Web-Dockerfile
+++ b/ops/packaging/Web-Dockerfile
@@ -9,6 +9,7 @@ COPY configuration/nginx-conf/enable_sites /usr/local/bin/enable_sites
 
 COPY configuration/gigadb-public/favicon.ico /var/www/favicon.ico
 COPY configuration/gigadb-public/index.php /var/www/index.php
+COPY configuration/gigadb-public/robots.txt /var/www/robots.txt
 
 COPY configuration/nginx-conf/sites/${GIGADB_ENV} /tmp/sites-available/
 COPY configuration/nginx-static /tmp/nginx-static/

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -5,8 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
     <?php if ( true || $metaData['private']) {//TODO: remove true|| when going to prod. or get env ?>
-        <meta name="robots" content="noindex">
-        <meta name="googlebot" content="noindex">
+        <meta name="robots" content="noindex, nofollow">
+        <meta name="googlebot" content="noindex, nofollow">
     <?php } ?>
     <?php if ($metaData['redirect']) {
             Yii::app()->clientScript->registerMetaTag("5;url={$metaData['redirect']}", null, 'refresh');

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
     <?php if ( true || $metaData['private']) {//TODO: remove true|| when going to prod. or get env ?>
-        <meta name="robots" content="noindex, nofollow">
+        <meta name="robots" content="noindex">
+        <meta name="googlebot" content="noindex">
     <?php } ?>
     <?php if ($metaData['redirect']) {
             Yii::app()->clientScript->registerMetaTag("5;url={$metaData['redirect']}", null, 'refresh');

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -5,8 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
     <?php if ( true || $metaData['private']) {//TODO: remove true|| when going to prod. or get env ?>
-        <meta name="robots" content="noindex">
-        <meta name="googlebot" content="noindex">
+        <meta name="robots" content="noindex, nofollow">
     <?php } ?>
     <?php if ($metaData['redirect']) {
             Yii::app()->clientScript->registerMetaTag("5;url={$metaData['redirect']}", null, 'refresh');

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -4,8 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex">
-    <meta name="googlebot" content="noindex">
+    <meta name="robots" content="noindex, nofollow">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -4,7 +4,8 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="noindex">
+    <meta name="googlebot" content="noindex">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -4,8 +4,8 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex">
-    <meta name="googlebot" content="noindex">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="googlebot" content="noindex, nofollow">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -4,8 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex">
-    <meta name="googlebot" content="noindex">
+    <meta name="robots" content="noindex, nofollow">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -4,7 +4,8 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="noindex">
+    <meta name="googlebot" content="noindex">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -4,8 +4,8 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="language" content="en" />
-    <meta name="robots" content="noindex">
-    <meta name="googlebot" content="noindex">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="googlebot" content="noindex, nofollow">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+# Block all web crawlers from crawling of all content
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This PR is for [#785](https://github.com/gigascience/gigadb-website/issues/785)

Tasks:
- [x] Create `robots.txt` that blocks all web crawlers in the root of the `gigadb-website`
- [x] Add `noindex, nofollow` to the meta tags `robots` and `googlebot`

To check the existence of meta tags with content `noindex, nofollow` in the following pages:
- [x] `/views/layouts/new_faq.php`
- [x] `/views/layouts/new_main.php`
- [x] `/views/layouts/new_datasetpage.php`
