### PR TITLE
Enable Yii migrations after import of production database backup for #792

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ $ docker-compose up csv-to-migrations
 $ docker-compose run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.data.dev --interactive=0
 ```
 
+>Note 1: When creating database migrations for changes to the database schema, ensure any creation of entity only happens if it doesn't exist already, i.e use: 
+> * ``CREATE TABLE IF NOT EXISTS``
+> * ``CREATE SEQUENCE IF NOT EXISTS``
+> * ``CREATE OR REPLACE VIEW``
+
+>Note 2: Occasionally, you may need to import database dumps and run the database migrations afterwards.
+> This will fail unless you run the following commands before the migrations in order to first drop existing constraints and indexes:
+> ```
+> $ docker-compose run --rm application ./protected/yiic custommigrations dropconstraints 
+> $ docker-compose run --rm application ./protected/yiic custommigrations dropindexes 
+>```
+
+
 ### Configuration variables
 
 The project can be configured using *deployment variables* managed in `.env`, 

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -53,8 +53,8 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefileformats
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefileformats
     # Generate the web certificate for TLS termination on web container.
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm config bash -c "cp /le.staging.ini /etc/letsencrypt/cli.ini && chmod 777 /var/www/assets"
     - ./ops/scripts/setup_cert.sh

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -48,7 +48,9 @@
     # deploy the web container once the application servers are up
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
-#    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
 #    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -45,6 +45,32 @@ ld_top:
     action: prepare
   when: manual
 
+sd_reset_migration:
+  variables:
+    GIGADB_ENV: staging
+  extends: .remote_compose
+  stage: staging deploy
+  script:
+    - *configure-docker-compose
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
+  environment:
+    name: staging
+    action: prepare
+  when: manual
+
+ld_reset_migration:
+  variables:
+    GIGADB_ENV: live
+  extends: .remote_compose
+  stage: live deploy
+  script:
+    - *configure-docker-compose
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --interactive=0
+  environment:
+    name: live
+    action: prepare
+  when: manual
+
 
 .teardown:
   extends: .remote_compose

--- a/ops/scripts/convert_production_db_to_latest_ver.sh
+++ b/ops/scripts/convert_production_db_to_latest_ver.sh
@@ -19,7 +19,7 @@ version=$($DOCKER_COMPOSE run --rm pg9_3 bash -c "psql --version | cut -d' ' -f 
 $DOCKER_COMPOSE run --rm updater ./yii dataset-files/download-restore-backup --latest
 
 echo "Export production data as text (only the strictly necessary data is exported)"
-$DOCKER_COMPOSE run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --schema=public --no-privileges --no-tablespaces gigadb -f sql/gigadbv3_"$latest"_v"$version".backup
+$DOCKER_COMPOSE run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname gigadb -f sql/gigadbv3_"$latest"_v"$version".backup
 
 if [[ $? -eq 0  && -f sql/gigadbv3_"$latest"_v"$version".backup ]];then
   echo "Finished convert production database to postgreSQL $version!"

--- a/ops/scripts/convert_production_db_to_latest_ver.sh
+++ b/ops/scripts/convert_production_db_to_latest_ver.sh
@@ -6,6 +6,8 @@ source ./.secrets
 
 latest=$(date -v-1d +"%Y%m%d")
 
+thedate=${1:-$latest}
+
 # docker-compose executable
 if [[ $GIGADB_ENV != "dev" && $GIGADB_ENV != "CI" ]];then
 	DOCKER_COMPOSE="docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml"
@@ -16,12 +18,12 @@ fi
 echo "Download and load the production database in to postgreSQL server using file-url-updater"
 cd gigadb/app/tools/files-url-updater/
 version=$($DOCKER_COMPOSE run --rm pg9_3 bash -c "psql --version | cut -d' ' -f 3 | tr -d '\n'")
-$DOCKER_COMPOSE run --rm updater ./yii dataset-files/download-restore-backup --latest
+$DOCKER_COMPOSE run --rm updater ./yii dataset-files/download-restore-backup --date $thedate
 
 echo "Export production data as text (only the strictly necessary data is exported)"
-$DOCKER_COMPOSE run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname gigadb -f sql/gigadbv3_"$latest"_v"$version".backup
+$DOCKER_COMPOSE run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname gigadb -f sql/gigadbv3_"$thedate"_v"$version".backup
 
-if [[ $? -eq 0  && -f sql/gigadbv3_"$latest"_v"$version".backup ]];then
+if [[ $? -eq 0  && -f sql/gigadbv3_"$thedate"_v"$version".backup ]];then
   echo "Finished convert production database to postgreSQL $version!"
 else
   echo "No upgraded database found, conversion fail!"

--- a/protected/commands/CustomMigrationsCommand.php
+++ b/protected/commands/CustomMigrationsCommand.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Command to drop all constraints and indexes
+ *
+ * @author Rija Menage <rija+git@cinecinetique.com>
+ * @license GPL-3.0
+ */
+class CustomMigrationsCommand extends CConsoleCommand
+{
+
+    public function getHelp()
+    {
+        $helpText = "drop constraints and indexes in the database" . PHP_EOL;
+        $helpText .= "Usage: ./protected/yiic custommigration dropconstraints" . PHP_EOL;
+        $helpText .= "Usage: ./protected/yiic custommigration dropindexes" . PHP_EOL;
+        return $helpText;
+    }
+
+    public function actionDropConstraints() {
+        $sql =<<<END
+SELECT nspname,relname, conname
+ FROM pg_constraint 
+ INNER JOIN pg_class ON conrelid=pg_class.oid 
+ INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace 
+ ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END,contype,nspname,relname,conname;
+END;
+
+        $dropCommands = [];
+        try {
+            $rows = Yii::app()->db->createCommand($sql)->queryAll();
+            foreach ($rows as $row) {
+                $dropCommands[]= "ALTER TABLE \"{$row['nspname']}\".\"{$row['relname']}\" DROP CONSTRAINT IF EXISTS {$row['conname']}";
+            }
+        } catch (CDbException $e) {
+            Yii::log($e->getMessage(),"error");
+            return 1;
+        }
+
+        try {
+            foreach ($dropCommands as $instruction) {
+                echo "About to execute: $instruction".PHP_EOL;
+                Yii::app()->db->createCommand($instruction)->execute();
+            }
+        }
+        catch(CDbException $e) {
+            Yii::log($e->getMessage(),"error");
+            return 1;
+        }
+
+    }
+
+    public function actionDropIndexes() {
+        $sql =<<<END
+SELECT nspname, relname 
+FROM pg_index 
+INNER JOIN pg_class ON indexrelid=pg_class.oid 
+INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace WHERE indisprimary=FALSE and indisvalid=TRUE AND nspname='public' ORDER BY nspname,relname;
+END;
+
+        $dropCommands = [];
+        try {
+            $rows = Yii::app()->db->createCommand($sql)->queryAll();
+            foreach ($rows as $row) {
+                $dropCommands[]= "DROP INDEX  \"{$row['nspname']}\".\"{$row['relname']}\" RESTRICT;";
+            }
+        } catch (CDbException $e) {
+            Yii::log($e->getMessage(),"error");
+            return 1;
+        }
+
+        try {
+            foreach ($dropCommands as $instruction) {
+                echo "About to execute: $instruction".PHP_EOL;
+                Yii::app()->db->createCommand($instruction)->execute();
+            }
+        }
+        catch(CDbException $e) {
+            Yii::log($e->getMessage(),"error");
+            return 1;
+        }
+
+    }
+
+
+}

--- a/protected/migrations/schema/m200528_050725_create_authitem_tab.php
+++ b/protected/migrations/schema/m200528_050725_create_authitem_tab.php
@@ -4,7 +4,7 @@ class m200528_050725_create_authitem_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE AuthItem (
+        $this->execute("CREATE TABLE IF NOT EXISTS AuthItem (
             name character varying(64) NOT NULL,
             type integer NOT NULL,
             description text,

--- a/protected/migrations/schema/m200528_050823_create_authassignment_tab.php
+++ b/protected/migrations/schema/m200528_050823_create_authassignment_tab.php
@@ -4,7 +4,7 @@ class m200528_050823_create_authassignment_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE AuthAssignment (
+        $this->execute("CREATE TABLE IF NOT EXISTS AuthAssignment (
             itemname character varying(64) NOT NULL,
             userid character varying(64) NOT NULL,
             bizrule text,

--- a/protected/migrations/schema/m200528_052836_create_extdb_tab.php
+++ b/protected/migrations/schema/m200528_052836_create_extdb_tab.php
@@ -4,7 +4,7 @@ class m200528_052836_create_extdb_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE extdb (
+        $this->execute("CREATE TABLE IF NOT EXISTS extdb (
             id integer NOT NULL,
             database_name character varying(100),
             definition character varying(1000),

--- a/protected/migrations/schema/m200528_052836_create_extdb_tab.php
+++ b/protected/migrations/schema/m200528_052836_create_extdb_tab.php
@@ -11,7 +11,7 @@ class m200528_052836_create_extdb_tab extends CDbMigration
             database_homepage character varying(100),
             database_search_url character varying(100));");
 
-        $this->execute("CREATE SEQUENCE extdb_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS extdb_id_seq
             START WITH 10
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_052850_create_species_tab.php
+++ b/protected/migrations/schema/m200528_052850_create_species_tab.php
@@ -4,7 +4,7 @@ class m200528_052850_create_species_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE species (
+        $this->execute("CREATE TABLE IF NOT EXISTS species (
             id integer NOT NULL,
             tax_id integer NOT NULL,
             common_name character varying(128),

--- a/protected/migrations/schema/m200528_052850_create_species_tab.php
+++ b/protected/migrations/schema/m200528_052850_create_species_tab.php
@@ -12,7 +12,7 @@ class m200528_052850_create_species_tab extends CDbMigration
             scientific_name character varying(128) NOT NULL,
             eol_link character varying(100));");
 
-        $this->execute("CREATE SEQUENCE species_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS species_id_seq
             START WITH 500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_052860_create_gigadb_user_tab.php
+++ b/protected/migrations/schema/m200528_052860_create_gigadb_user_tab.php
@@ -4,7 +4,7 @@ class m200528_052860_create_gigadb_user_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE gigadb_user (
+        $this->execute("CREATE TABLE IF NOT EXISTS gigadb_user (
             id integer NOT NULL,
             email character varying(64) NOT NULL,
             password character varying(128) NOT NULL,

--- a/protected/migrations/schema/m200528_052860_create_gigadb_user_tab.php
+++ b/protected/migrations/schema/m200528_052860_create_gigadb_user_tab.php
@@ -23,7 +23,7 @@ class m200528_052860_create_gigadb_user_tab extends CDbMigration
             orcid_id text,
             preferred_link character varying(128) DEFAULT 'EBI'::character varying);");
 
-        $this->execute("CREATE SEQUENCE gigadb_user_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS gigadb_user_id_seq 
             START WITH 20 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200528_052880_create_sample_tab.php
+++ b/protected/migrations/schema/m200528_052880_create_sample_tab.php
@@ -15,7 +15,7 @@ class m200528_052880_create_sample_tab extends CDbMigration
             contact_author_email character varying(100),
             sampling_protocol character varying(100));");
 
-        $this->execute("CREATE SEQUENCE sample_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS sample_id_seq
             START WITH 500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_052880_create_sample_tab.php
+++ b/protected/migrations/schema/m200528_052880_create_sample_tab.php
@@ -25,7 +25,7 @@ class m200528_052880_create_sample_tab extends CDbMigration
         $this->execute("ALTER SEQUENCE sample_id_seq 
             OWNED BY sample.id;");
 
-        $this->execute("CREATE VIEW sample_number AS
+        $this->execute("CREATE OR REPLACE VIEW sample_number AS
             SELECT count(sample.id) AS count FROM sample;");
 
         $this->execute("ALTER TABLE ONLY sample 

--- a/protected/migrations/schema/m200528_052880_create_sample_tab.php
+++ b/protected/migrations/schema/m200528_052880_create_sample_tab.php
@@ -4,7 +4,7 @@ class m200528_052880_create_sample_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE sample (
+        $this->execute("CREATE TABLE IF NOT EXISTS sample (
             id integer NOT NULL,
             species_id integer NOT NULL,
             name character varying(100) DEFAULT 'SAMPLE:SRS188811'::character varying NOT NULL,

--- a/protected/migrations/schema/m200528_052900_create_alternative_identifiers_tab.php
+++ b/protected/migrations/schema/m200528_052900_create_alternative_identifiers_tab.php
@@ -10,7 +10,7 @@ class m200528_052900_create_alternative_identifiers_tab extends CDbMigration
             extdb_id integer NOT NULL,
             extdb_accession character varying(100));");
 
-        $this->execute("CREATE SEQUENCE alternative_identifiers_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS alternative_identifiers_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_052900_create_alternative_identifiers_tab.php
+++ b/protected/migrations/schema/m200528_052900_create_alternative_identifiers_tab.php
@@ -4,7 +4,7 @@ class m200528_052900_create_alternative_identifiers_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE alternative_identifiers (
+        $this->execute("CREATE TABLE IF NOT EXISTS alternative_identifiers (
             id integer NOT NULL,
             sample_id integer NOT NULL,
             extdb_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_053712_create_attribute_tab.php
+++ b/protected/migrations/schema/m200528_053712_create_attribute_tab.php
@@ -4,7 +4,7 @@ class m200528_053712_create_attribute_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE attribute (
+        $this->execute("CREATE TABLE IF NOT EXISTS attribute (
             id integer NOT NULL,
             attribute_name character varying(100),
             definition character varying(1000),

--- a/protected/migrations/schema/m200528_053712_create_attribute_tab.php
+++ b/protected/migrations/schema/m200528_053712_create_attribute_tab.php
@@ -16,7 +16,7 @@ class m200528_053712_create_attribute_tab extends CDbMigration
             ontology_link character varying(1000),
             note character varying(100));");
 
-        $this->execute("CREATE SEQUENCE attribute_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS attribute_id_seq
             START WITH 700
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_054920_create_author_tab.php
+++ b/protected/migrations/schema/m200528_054920_create_author_tab.php
@@ -13,7 +13,7 @@ class m200528_054920_create_author_tab extends CDbMigration
             gigadb_user_id integer,
             custom_name character varying(100));");
 
-        $this->execute("CREATE SEQUENCE author_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS author_id_seq
             START WITH 3500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_054920_create_author_tab.php
+++ b/protected/migrations/schema/m200528_054920_create_author_tab.php
@@ -4,7 +4,7 @@ class m200528_054920_create_author_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE author (
+        $this->execute("CREATE TABLE IF NOT EXISTS author (
             id integer NOT NULL,
             surname character varying(255) NOT NULL,
             middle_name character varying(255),

--- a/protected/migrations/schema/m200528_054960_create_author_rel_tab.php
+++ b/protected/migrations/schema/m200528_054960_create_author_rel_tab.php
@@ -4,7 +4,7 @@ class m200528_054960_create_author_rel_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE author_rel (
+        $this->execute("CREATE TABLE IF NOT EXISTS author_rel (
             id integer NOT NULL,
             author_id integer NOT NULL,
             related_author_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_054960_create_author_rel_tab.php
+++ b/protected/migrations/schema/m200528_054960_create_author_rel_tab.php
@@ -10,7 +10,7 @@ class m200528_054960_create_author_rel_tab extends CDbMigration
             related_author_id integer NOT NULL,
             relationship_id integer);");
 
-        $this->execute("CREATE SEQUENCE author_rel_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS author_rel_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_055005_create_image_tab.php
+++ b/protected/migrations/schema/m200528_055005_create_image_tab.php
@@ -13,7 +13,7 @@ class m200528_055005_create_image_tab extends CDbMigration
             photographer character varying(128) NOT NULL,
             source character varying(256) NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE image_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS image_id_seq 
             START WITH 40 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200528_055005_create_image_tab.php
+++ b/protected/migrations/schema/m200528_055005_create_image_tab.php
@@ -4,7 +4,7 @@ class m200528_055005_create_image_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE image (
+        $this->execute("CREATE TABLE IF NOT EXISTS image (
             id integer NOT NULL,
             location character varying(200) DEFAULT ''::character varying NOT NULL,
             tag character varying(300),

--- a/protected/migrations/schema/m200528_055100_create_publisher_tab.php
+++ b/protected/migrations/schema/m200528_055100_create_publisher_tab.php
@@ -9,7 +9,7 @@ class m200528_055100_create_publisher_tab extends CDbMigration
             name character varying(45) NOT NULL,
             description text DEFAULT ''::text NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE publisher_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS publisher_id_seq 
             START WITH 10 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200528_055100_create_publisher_tab.php
+++ b/protected/migrations/schema/m200528_055100_create_publisher_tab.php
@@ -4,7 +4,7 @@ class m200528_055100_create_publisher_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE publisher (
+        $this->execute("CREATE TABLE IF NOT EXISTS publisher (
             id integer NOT NULL,
             name character varying(45) NOT NULL,
             description text DEFAULT ''::text NOT NULL);");

--- a/protected/migrations/schema/m200528_055110_create_dataset_tab.php
+++ b/protected/migrations/schema/m200528_055110_create_dataset_tab.php
@@ -4,7 +4,7 @@ class m200528_055110_create_dataset_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset (
             id integer NOT NULL,
             submitter_id integer NOT NULL,
             image_id integer,

--- a/protected/migrations/schema/m200528_055110_create_dataset_tab.php
+++ b/protected/migrations/schema/m200528_055110_create_dataset_tab.php
@@ -25,7 +25,7 @@ class m200528_055110_create_dataset_tab extends CDbMigration
             manuscript_id character varying(50),
             handing_editor character varying(50));");
 
-        $this->execute("CREATE SEQUENCE dataset_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_id_seq 
             START WITH 50 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200528_055350_create_curation_log_tab.php
+++ b/protected/migrations/schema/m200528_055350_create_curation_log_tab.php
@@ -5,7 +5,7 @@ class m200528_055350_create_curation_log_tab extends CDbMigration
     // Use safeUp/safeDown to do migration with transaction
     public function safeUp()
     {
-        $this->execute("CREATE TABLE curation_log (
+        $this->execute("CREATE TABLE IF NOT EXISTS curation_log (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             creation_date date,

--- a/protected/migrations/schema/m200528_055350_create_curation_log_tab.php
+++ b/protected/migrations/schema/m200528_055350_create_curation_log_tab.php
@@ -15,7 +15,7 @@ class m200528_055350_create_curation_log_tab extends CDbMigration
             action character varying(100),
             comments character varying(1000));");
 
-        $this->execute("CREATE SEQUENCE curation_log_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS curation_log_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_057932_create_unit_tab.php
+++ b/protected/migrations/schema/m200528_057932_create_unit_tab.php
@@ -4,7 +4,7 @@ class m200528_057932_create_unit_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE unit (
+        $this->execute("CREATE TABLE IF NOT EXISTS unit (
             id character varying(30) NOT NULL,
             name character varying(200),
             definition character varying(500));");

--- a/protected/migrations/schema/m200528_060345_create_dataset_attributes_tab.php
+++ b/protected/migrations/schema/m200528_060345_create_dataset_attributes_tab.php
@@ -13,7 +13,7 @@ class m200528_060345_create_dataset_attributes_tab extends CDbMigration
             image_id integer,
             until_date date);");
 
-        $this->execute("CREATE SEQUENCE dataset_attributes_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_attributes_id_seq
             START WITH 2500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_060345_create_dataset_attributes_tab.php
+++ b/protected/migrations/schema/m200528_060345_create_dataset_attributes_tab.php
@@ -4,7 +4,7 @@ class m200528_060345_create_dataset_attributes_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_attributes (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_attributes (
             id integer NOT NULL,
             dataset_id integer,
             attribute_id integer,

--- a/protected/migrations/schema/m200528_060906_create_dataset_author_tab.php
+++ b/protected/migrations/schema/m200528_060906_create_dataset_author_tab.php
@@ -11,7 +11,7 @@ class m200528_060906_create_dataset_author_tab extends CDbMigration
             rank integer DEFAULT 0,
             role character varying(30));");
 
-        $this->execute("CREATE SEQUENCE dataset_author_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_author_id_seq
             START WITH 200
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_060906_create_dataset_author_tab.php
+++ b/protected/migrations/schema/m200528_060906_create_dataset_author_tab.php
@@ -4,7 +4,7 @@ class m200528_060906_create_dataset_author_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_author (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_author (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             author_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_061005_create_funder_name_tab.php
+++ b/protected/migrations/schema/m200528_061005_create_funder_name_tab.php
@@ -4,7 +4,7 @@ class m200528_061005_create_funder_name_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE funder_name (
+        $this->execute("CREATE TABLE IF NOT EXISTS funder_name (
             id integer NOT NULL,
             uri character varying(100) NOT NULL,
             primary_name_display character varying(1000),

--- a/protected/migrations/schema/m200528_061005_create_funder_name_tab.php
+++ b/protected/migrations/schema/m200528_061005_create_funder_name_tab.php
@@ -10,7 +10,7 @@ class m200528_061005_create_funder_name_tab extends CDbMigration
             primary_name_display character varying(1000),
             country character varying(128) DEFAULT ''::character varying);");
 
-        $this->execute("CREATE SEQUENCE funder_name_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS funder_name_id_seq
             START WITH 6200
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_061339_create_dataset_funder_tab.php
+++ b/protected/migrations/schema/m200528_061339_create_dataset_funder_tab.php
@@ -12,7 +12,7 @@ class m200528_061339_create_dataset_funder_tab extends CDbMigration
             comments text DEFAULT ''::text,
             awardee character varying(100));");
 
-        $this->execute("CREATE SEQUENCE dataset_funder_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_funder_id_seq
             START WITH 50
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_061339_create_dataset_funder_tab.php
+++ b/protected/migrations/schema/m200528_061339_create_dataset_funder_tab.php
@@ -4,7 +4,7 @@ class m200528_061339_create_dataset_funder_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_funder (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_funder (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             funder_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_061933_create_dataset_log_tab.php
+++ b/protected/migrations/schema/m200528_061933_create_dataset_log_tab.php
@@ -4,7 +4,7 @@ class m200528_061933_create_dataset_log_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_log (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_log (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             message text DEFAULT ''::text,

--- a/protected/migrations/schema/m200528_061933_create_dataset_log_tab.php
+++ b/protected/migrations/schema/m200528_061933_create_dataset_log_tab.php
@@ -13,7 +13,7 @@ class m200528_061933_create_dataset_log_tab extends CDbMigration
             model_id integer,
             url text DEFAULT ''::text);");
 
-        $this->execute("CREATE SEQUENCE dataset_log_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_log_id_seq
             START WITH 1200
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_063052_create_project_tab.php
+++ b/protected/migrations/schema/m200528_063052_create_project_tab.php
@@ -4,7 +4,7 @@ class m200528_063052_create_project_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE project (
+        $this->execute("CREATE TABLE IF NOT EXISTS project (
             id integer NOT NULL,
             url character varying(128) NOT NULL,
             name character varying(255) DEFAULT ''::character varying NOT NULL,

--- a/protected/migrations/schema/m200528_063052_create_project_tab.php
+++ b/protected/migrations/schema/m200528_063052_create_project_tab.php
@@ -10,7 +10,7 @@ class m200528_063052_create_project_tab extends CDbMigration
             name character varying(255) DEFAULT ''::character varying NOT NULL,
             image_location character varying(100));");
 
-        $this->execute("CREATE SEQUENCE project_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS project_id_seq
             START WITH 10
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_064612_create_dataset_project_tab.php
+++ b/protected/migrations/schema/m200528_064612_create_dataset_project_tab.php
@@ -4,7 +4,7 @@ class m200528_064612_create_dataset_project_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_project (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_project (
             id integer NOT NULL,
             dataset_id integer,
             project_id integer);");

--- a/protected/migrations/schema/m200528_064612_create_dataset_project_tab.php
+++ b/protected/migrations/schema/m200528_064612_create_dataset_project_tab.php
@@ -9,7 +9,7 @@ class m200528_064612_create_dataset_project_tab extends CDbMigration
             dataset_id integer,
             project_id integer);");
 
-        $this->execute("CREATE SEQUENCE dataset_project_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_project_id_seq
             START WITH 20
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_065011_create_dataset_sample_tab.php
+++ b/protected/migrations/schema/m200528_065011_create_dataset_sample_tab.php
@@ -4,7 +4,7 @@ class m200528_065011_create_dataset_sample_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_sample (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_sample (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             sample_id integer NOT NULL);");

--- a/protected/migrations/schema/m200528_065011_create_dataset_sample_tab.php
+++ b/protected/migrations/schema/m200528_065011_create_dataset_sample_tab.php
@@ -9,7 +9,7 @@ class m200528_065011_create_dataset_sample_tab extends CDbMigration
             dataset_id integer NOT NULL,
             sample_id integer NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE dataset_sample_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_sample_id_seq
             START WITH 500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_065406_create_dataset_session_tab.php
+++ b/protected/migrations/schema/m200528_065406_create_dataset_session_tab.php
@@ -18,7 +18,7 @@ class m200528_065406_create_dataset_session_tab extends CDbMigration
             relations text,
             samples text);");
 
-        $this->execute("CREATE SEQUENCE dataset_session_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_session_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_065406_create_dataset_session_tab.php
+++ b/protected/migrations/schema/m200528_065406_create_dataset_session_tab.php
@@ -4,7 +4,7 @@ class m200528_065406_create_dataset_session_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_session (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_session (
             id integer NOT NULL,
             identifier text NOT NULL,
             dataset text,

--- a/protected/migrations/schema/m200528_065513_create_type_tab.php
+++ b/protected/migrations/schema/m200528_065513_create_type_tab.php
@@ -4,7 +4,7 @@ class m200528_065513_create_type_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE type (
+        $this->execute("CREATE TABLE IF NOT EXISTS type (
             id integer NOT NULL,
             name character varying(32) NOT NULL,
             description text DEFAULT ''::text NOT NULL);");

--- a/protected/migrations/schema/m200528_065513_create_type_tab.php
+++ b/protected/migrations/schema/m200528_065513_create_type_tab.php
@@ -9,7 +9,7 @@ class m200528_065513_create_type_tab extends CDbMigration
             name character varying(32) NOT NULL,
             description text DEFAULT ''::text NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE type_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS type_id_seq 
             START WITH 30 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200528_065837_create_dataset_type_tab.php
+++ b/protected/migrations/schema/m200528_065837_create_dataset_type_tab.php
@@ -4,7 +4,7 @@ class m200528_065837_create_dataset_type_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE dataset_type (
+        $this->execute("CREATE TABLE IF NOT EXISTS dataset_type (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             type_id integer);");

--- a/protected/migrations/schema/m200528_065837_create_dataset_type_tab.php
+++ b/protected/migrations/schema/m200528_065837_create_dataset_type_tab.php
@@ -9,7 +9,7 @@ class m200528_065837_create_dataset_type_tab extends CDbMigration
             dataset_id integer NOT NULL,
             type_id integer);");
 
-        $this->execute("CREATE SEQUENCE dataset_type_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS dataset_type_id_seq
             START WITH 50
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_066022_create_experiment_tab.php
+++ b/protected/migrations/schema/m200528_066022_create_experiment_tab.php
@@ -4,7 +4,7 @@ class m200528_066022_create_experiment_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE experiment (
+        $this->execute("CREATE TABLE IF NOT EXISTS experiment (
             id integer NOT NULL,
             experiment_type character varying(100),
             experiment_name character varying(100),

--- a/protected/migrations/schema/m200528_066022_create_experiment_tab.php
+++ b/protected/migrations/schema/m200528_066022_create_experiment_tab.php
@@ -12,7 +12,7 @@ class m200528_066022_create_experiment_tab extends CDbMigration
             dataset_id integer,
             \"protocols.io\" character varying(200));");
 
-        $this->execute("CREATE SEQUENCE experiment_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS experiment_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_070231_create_exp_attributes_tab.php
+++ b/protected/migrations/schema/m200528_070231_create_exp_attributes_tab.php
@@ -11,7 +11,7 @@ class m200528_070231_create_exp_attributes_tab extends CDbMigration
             value character varying(1000),
             units_id character varying(50));");
 
-        $this->execute("CREATE SEQUENCE exp_attributes_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS exp_attributes_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_070231_create_exp_attributes_tab.php
+++ b/protected/migrations/schema/m200528_070231_create_exp_attributes_tab.php
@@ -4,7 +4,7 @@ class m200528_070231_create_exp_attributes_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE exp_attributes (
+        $this->execute("CREATE TABLE IF NOT EXISTS exp_attributes (
             id integer NOT NULL,
             exp_id integer,
             attribute_id integer,

--- a/protected/migrations/schema/m200528_071027_create_external_link_type_tab.php
+++ b/protected/migrations/schema/m200528_071027_create_external_link_type_tab.php
@@ -8,7 +8,7 @@ class m200528_071027_create_external_link_type_tab extends CDbMigration
             id integer NOT NULL,
             name character varying(45) NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE external_link_type_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS external_link_type_id_seq
             START WITH 10
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_071027_create_external_link_type_tab.php
+++ b/protected/migrations/schema/m200528_071027_create_external_link_type_tab.php
@@ -4,7 +4,7 @@ class m200528_071027_create_external_link_type_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE external_link_type (
+        $this->execute("CREATE TABLE IF NOT EXISTS external_link_type (
             id integer NOT NULL,
             name character varying(45) NOT NULL);");
 

--- a/protected/migrations/schema/m200528_071227_create_external_link_tab.php
+++ b/protected/migrations/schema/m200528_071227_create_external_link_tab.php
@@ -4,7 +4,7 @@ class m200528_071227_create_external_link_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE external_link (
+        $this->execute("CREATE TABLE IF NOT EXISTS external_link (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             url character varying(300) NOT NULL,

--- a/protected/migrations/schema/m200528_071227_create_external_link_tab.php
+++ b/protected/migrations/schema/m200528_071227_create_external_link_tab.php
@@ -10,7 +10,7 @@ class m200528_071227_create_external_link_tab extends CDbMigration
             url character varying(300) NOT NULL,
             external_link_type_id integer NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE external_link_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS external_link_id_seq
             START WITH 1000
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_072037_create_file_format_tab.php
+++ b/protected/migrations/schema/m200528_072037_create_file_format_tab.php
@@ -10,7 +10,7 @@ class m200528_072037_create_file_format_tab extends CDbMigration
             description text DEFAULT ''::text NOT NULL,
             edam_ontology_id character varying(100));");
 
-        $this->execute("CREATE SEQUENCE file_format_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_format_id_seq
             START WITH 100
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_072037_create_file_format_tab.php
+++ b/protected/migrations/schema/m200528_072037_create_file_format_tab.php
@@ -4,7 +4,7 @@ class m200528_072037_create_file_format_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_format (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_format (
             id integer NOT NULL,
             name character varying(20) NOT NULL,
             description text DEFAULT ''::text NOT NULL,

--- a/protected/migrations/schema/m200528_072552_create_file_type_tab.php
+++ b/protected/migrations/schema/m200528_072552_create_file_type_tab.php
@@ -10,7 +10,7 @@ class m200528_072552_create_file_type_tab extends CDbMigration
             description text DEFAULT ''::text NOT NULL,
             edam_ontology_id character varying(100));");
 
-        $this->execute("CREATE SEQUENCE file_type_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_type_id_seq
             START WITH 200
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_072552_create_file_type_tab.php
+++ b/protected/migrations/schema/m200528_072552_create_file_type_tab.php
@@ -4,7 +4,7 @@ class m200528_072552_create_file_type_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_type (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_type (
             id integer NOT NULL,
             name character varying(100) NOT NULL,
             description text DEFAULT ''::text NOT NULL,

--- a/protected/migrations/schema/m200528_075520_create_file_tab.php
+++ b/protected/migrations/schema/m200528_075520_create_file_tab.php
@@ -20,7 +20,7 @@ class m200528_075520_create_file_tab extends CDbMigration
             download_count integer DEFAULT 0 NOT NULL,
             alternative_location character varying(200));");
 
-        $this->execute("CREATE SEQUENCE file_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_id_seq
             START WITH 6300
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_075520_create_file_tab.php
+++ b/protected/migrations/schema/m200528_075520_create_file_tab.php
@@ -4,7 +4,7 @@ class m200528_075520_create_file_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file (
+        $this->execute("CREATE TABLE IF NOT EXISTS file (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             name character varying(200) NOT NULL,

--- a/protected/migrations/schema/m200528_075520_create_file_tab.php
+++ b/protected/migrations/schema/m200528_075520_create_file_tab.php
@@ -30,7 +30,7 @@ class m200528_075520_create_file_tab extends CDbMigration
         $this->execute("ALTER SEQUENCE file_id_seq 
             OWNED BY file.id;");
 
-        $this->execute("CREATE VIEW file_number AS
+        $this->execute("CREATE OR REPLACE VIEW file_number AS
             SELECT count(file.id) AS count 
             FROM file;");
 

--- a/protected/migrations/schema/m200528_090557_create_file_attributes_tab.php
+++ b/protected/migrations/schema/m200528_090557_create_file_attributes_tab.php
@@ -11,7 +11,7 @@ class m200528_090557_create_file_attributes_tab extends CDbMigration
             value character varying(1000),
             unit_id character varying(30));");
 
-        $this->execute("CREATE SEQUENCE file_attributes_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_attributes_id_seq
             START WITH 11000
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_090557_create_file_attributes_tab.php
+++ b/protected/migrations/schema/m200528_090557_create_file_attributes_tab.php
@@ -4,7 +4,7 @@ class m200528_090557_create_file_attributes_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_attributes (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_attributes (
             id integer NOT NULL,
             file_id integer NOT NULL,
             attribute_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_091351_create_file_experiment_tab.php
+++ b/protected/migrations/schema/m200528_091351_create_file_experiment_tab.php
@@ -9,7 +9,7 @@ class m200528_091351_create_file_experiment_tab extends CDbMigration
             file_id integer,
             experiment_id integer);");
 
-        $this->execute("CREATE SEQUENCE file_experiment_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_experiment_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_091351_create_file_experiment_tab.php
+++ b/protected/migrations/schema/m200528_091351_create_file_experiment_tab.php
@@ -4,7 +4,7 @@ class m200528_091351_create_file_experiment_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_experiment (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_experiment (
             id integer NOT NULL,
             file_id integer,
             experiment_id integer);");

--- a/protected/migrations/schema/m200528_091646_create_relationship_tab.php
+++ b/protected/migrations/schema/m200528_091646_create_relationship_tab.php
@@ -8,7 +8,7 @@ class m200528_091646_create_relationship_tab extends CDbMigration
             id integer NOT NULL,
             name character varying(100));");
 
-        $this->execute("CREATE SEQUENCE relationship_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS relationship_id_seq
             START WITH 40
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_091646_create_relationship_tab.php
+++ b/protected/migrations/schema/m200528_091646_create_relationship_tab.php
@@ -4,7 +4,7 @@ class m200528_091646_create_relationship_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE relationship (
+        $this->execute("CREATE TABLE IF NOT EXISTS relationship (
             id integer NOT NULL,
             name character varying(100));");
 

--- a/protected/migrations/schema/m200528_092231_create_file_relationship_tab.php
+++ b/protected/migrations/schema/m200528_092231_create_file_relationship_tab.php
@@ -4,7 +4,7 @@ class m200528_092231_create_file_relationship_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_relationship (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_relationship (
             id integer NOT NULL,
             file_id integer NOT NULL,
             related_file_id integer NOT NULL,

--- a/protected/migrations/schema/m200528_092231_create_file_relationship_tab.php
+++ b/protected/migrations/schema/m200528_092231_create_file_relationship_tab.php
@@ -10,7 +10,7 @@ class m200528_092231_create_file_relationship_tab extends CDbMigration
             related_file_id integer NOT NULL,
             relationship_id integer);");
 
-        $this->execute("CREATE SEQUENCE file_relationship_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_relationship_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_092609_create_file_sample_tab.php
+++ b/protected/migrations/schema/m200528_092609_create_file_sample_tab.php
@@ -9,7 +9,7 @@ class m200528_092609_create_file_sample_tab extends CDbMigration
             sample_id integer NOT NULL,
             file_id integer NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE file_sample_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS file_sample_id_seq
             START WITH 5800
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200528_092609_create_file_sample_tab.php
+++ b/protected/migrations/schema/m200528_092609_create_file_sample_tab.php
@@ -4,7 +4,7 @@ class m200528_092609_create_file_sample_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE file_sample (
+        $this->execute("CREATE TABLE IF NOT EXISTS file_sample (
             id integer NOT NULL,
             sample_id integer NOT NULL,
             file_id integer NOT NULL);");

--- a/protected/migrations/schema/m200529_020859_create_link_tab.php
+++ b/protected/migrations/schema/m200529_020859_create_link_tab.php
@@ -11,7 +11,7 @@ class m200529_020859_create_link_tab extends CDbMigration
             link character varying(100) NOT NULL,
             description character varying(200));");
 
-        $this->execute("CREATE SEQUENCE link_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS link_id_seq
             START WITH 80
             INCREMENT BY 1
             NO MINVALUE
@@ -21,7 +21,7 @@ class m200529_020859_create_link_tab extends CDbMigration
         $this->execute("ALTER SEQUENCE link_id_seq 
             OWNED BY link.id;");
 
-        $this->execute("CREATE SEQUENCE link_prefix_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS link_prefix_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_020859_create_link_tab.php
+++ b/protected/migrations/schema/m200529_020859_create_link_tab.php
@@ -4,7 +4,7 @@ class m200529_020859_create_link_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE link (
+        $this->execute("CREATE TABLE IF NOT EXISTS link (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             is_primary boolean DEFAULT false NOT NULL,

--- a/protected/migrations/schema/m200529_021512_create_manuscript_tab.php
+++ b/protected/migrations/schema/m200529_021512_create_manuscript_tab.php
@@ -10,7 +10,7 @@ class m200529_021512_create_manuscript_tab extends CDbMigration
             pmid integer,
             dataset_id integer NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE manuscript_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS manuscript_id_seq
             START WITH 500
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_021512_create_manuscript_tab.php
+++ b/protected/migrations/schema/m200529_021512_create_manuscript_tab.php
@@ -4,7 +4,7 @@ class m200529_021512_create_manuscript_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE manuscript (
+        $this->execute("CREATE TABLE IF NOT EXISTS manuscript (
             id integer NOT NULL,
             identifier character varying(32) NOT NULL,
             pmid integer,

--- a/protected/migrations/schema/m200529_022144_create_news_tab.php
+++ b/protected/migrations/schema/m200529_022144_create_news_tab.php
@@ -11,7 +11,7 @@ class m200529_022144_create_news_tab extends CDbMigration
             start_date date NOT NULL,
             end_date date NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE news_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS news_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_022144_create_news_tab.php
+++ b/protected/migrations/schema/m200529_022144_create_news_tab.php
@@ -4,7 +4,7 @@ class m200529_022144_create_news_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE news (
+        $this->execute("CREATE TABLE IF NOT EXISTS news (
             id integer NOT NULL,
             title character varying(200) NOT NULL,
             body text DEFAULT ''::text NOT NULL,

--- a/protected/migrations/schema/m200529_022516_create_prefix_tab.php
+++ b/protected/migrations/schema/m200529_022516_create_prefix_tab.php
@@ -4,7 +4,7 @@ class m200529_022516_create_prefix_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE prefix (
+        $this->execute("CREATE TABLE IF NOT EXISTS prefix (
             id integer DEFAULT nextval('link_prefix_id_seq'::regclass) NOT NULL,
             prefix character(20) NOT NULL,
             url text NOT NULL,

--- a/protected/migrations/schema/m200529_023319_create_relation_tab.php
+++ b/protected/migrations/schema/m200529_023319_create_relation_tab.php
@@ -10,7 +10,7 @@ class m200529_023319_create_relation_tab extends CDbMigration
             related_doi character varying(15) NOT NULL,
             relationship_id integer);");
 
-        $this->execute("CREATE SEQUENCE relation_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS relation_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_023319_create_relation_tab.php
+++ b/protected/migrations/schema/m200529_023319_create_relation_tab.php
@@ -4,7 +4,7 @@ class m200529_023319_create_relation_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE relation (
+        $this->execute("CREATE TABLE IF NOT EXISTS relation (
             id integer NOT NULL,
             dataset_id integer NOT NULL,
             related_doi character varying(15) NOT NULL,

--- a/protected/migrations/schema/m200529_024441_create_rss_message_tab.php
+++ b/protected/migrations/schema/m200529_024441_create_rss_message_tab.php
@@ -9,7 +9,7 @@ class m200529_024441_create_rss_message_tab extends CDbMigration
             message character varying(128) NOT NULL,
             publication_date date DEFAULT ('now'::text)::date NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE rss_message_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS rss_message_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_024441_create_rss_message_tab.php
+++ b/protected/migrations/schema/m200529_024441_create_rss_message_tab.php
@@ -4,7 +4,7 @@ class m200529_024441_create_rss_message_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE rss_message (
+        $this->execute("CREATE TABLE IF NOT EXISTS rss_message (
             id integer NOT NULL,
             message character varying(128) NOT NULL,
             publication_date date DEFAULT ('now'::text)::date NOT NULL);");

--- a/protected/migrations/schema/m200529_025806_create_sample_attribute_tab.php
+++ b/protected/migrations/schema/m200529_025806_create_sample_attribute_tab.php
@@ -11,7 +11,7 @@ class m200529_025806_create_sample_attribute_tab extends CDbMigration
             value character varying(10000),
             unit_id character varying(30));");
 
-        $this->execute("CREATE SEQUENCE sample_attribute_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS sample_attribute_id_seq
             START WITH 30000
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_025806_create_sample_attribute_tab.php
+++ b/protected/migrations/schema/m200529_025806_create_sample_attribute_tab.php
@@ -4,7 +4,7 @@ class m200529_025806_create_sample_attribute_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE sample_attribute (
+        $this->execute("CREATE TABLE IF NOT EXISTS sample_attribute (
             id integer NOT NULL,
             sample_id integer NOT NULL,
             attribute_id integer NOT NULL,

--- a/protected/migrations/schema/m200529_030439_create_sample_experiment_tab.php
+++ b/protected/migrations/schema/m200529_030439_create_sample_experiment_tab.php
@@ -9,7 +9,7 @@ class m200529_030439_create_sample_experiment_tab extends CDbMigration
             sample_id integer,
             experiment_id integer);");
 
-        $this->execute("CREATE SEQUENCE sample_experiment_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS sample_experiment_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_030439_create_sample_experiment_tab.php
+++ b/protected/migrations/schema/m200529_030439_create_sample_experiment_tab.php
@@ -4,7 +4,7 @@ class m200529_030439_create_sample_experiment_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE sample_experiment (
+        $this->execute("CREATE TABLE IF NOT EXISTS sample_experiment (
             id integer NOT NULL,
             sample_id integer,
             experiment_id integer);");

--- a/protected/migrations/schema/m200529_030927_create_sample_rel_tab.php
+++ b/protected/migrations/schema/m200529_030927_create_sample_rel_tab.php
@@ -10,7 +10,7 @@ class m200529_030927_create_sample_rel_tab extends CDbMigration
             related_sample_id integer NOT NULL,
             relationship_id integer);");
 
-        $this->execute("CREATE SEQUENCE sample_rel_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS sample_rel_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_030927_create_sample_rel_tab.php
+++ b/protected/migrations/schema/m200529_030927_create_sample_rel_tab.php
@@ -4,7 +4,7 @@ class m200529_030927_create_sample_rel_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE sample_rel (
+        $this->execute("CREATE TABLE IF NOT EXISTS sample_rel (
             id integer NOT NULL,
             sample_id integer NOT NULL,
             related_sample_id integer NOT NULL,

--- a/protected/migrations/schema/m200529_032549_create_search_tab.php
+++ b/protected/migrations/schema/m200529_032549_create_search_tab.php
@@ -11,7 +11,7 @@ class m200529_032549_create_search_tab extends CDbMigration
             query text NOT NULL,
             result text);");
 
-        $this->execute("CREATE SEQUENCE search_id_seq 
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS search_id_seq 
             START WITH 1 
             INCREMENT BY 1 
             NO MINVALUE 

--- a/protected/migrations/schema/m200529_032549_create_search_tab.php
+++ b/protected/migrations/schema/m200529_032549_create_search_tab.php
@@ -4,7 +4,7 @@ class m200529_032549_create_search_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE search (
+        $this->execute("CREATE TABLE IF NOT EXISTS search (
             id integer NOT NULL,
             user_id integer NOT NULL,
             name character varying(128) NOT NULL,

--- a/protected/migrations/schema/m200529_032907_create_show_accession_view.php
+++ b/protected/migrations/schema/m200529_032907_create_show_accession_view.php
@@ -4,7 +4,7 @@ class m200529_032907_create_show_accession_view extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE VIEW show_accession AS
+        $this->execute("CREATE OR REPLACE VIEW show_accession AS
             SELECT ('DOI: '::text || (dataset.identifier)::text) AS doi_number, 
             link.link AS related_accessions 
             FROM (dataset JOIN link ON ((dataset.id = link.dataset_id)));");

--- a/protected/migrations/schema/m200529_033116_create_show_manuscript_view.php
+++ b/protected/migrations/schema/m200529_033116_create_show_manuscript_view.php
@@ -4,7 +4,7 @@ class m200529_033116_create_show_manuscript_view extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE VIEW show_manuscript AS
+        $this->execute("CREATE OR REPLACE VIEW show_manuscript AS
             SELECT ('DOI: '::text || (dataset.identifier)::text) AS doi_number, 
             manuscript.identifier AS related_manuscript 
             FROM (dataset JOIN manuscript ON ((dataset.id = manuscript.dataset_id)));");

--- a/protected/migrations/schema/m200529_033307_create_show_project_view.php
+++ b/protected/migrations/schema/m200529_033307_create_show_project_view.php
@@ -4,7 +4,7 @@ class m200529_033307_create_show_project_view extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE VIEW show_project AS
+        $this->execute("CREATE OR REPLACE VIEW show_project AS
             SELECT ('DOI: '::text || (dataset.identifier)::text) AS doi_number, 
             project.name AS project 
             FROM ((dataset JOIN dataset_project ON ((dataset.id = dataset_project.dataset_id))) JOIN project ON ((dataset_project.project_id = project.id)));");

--- a/protected/migrations/schema/m200529_034715_create_view_homepage_dataset_type.php
+++ b/protected/migrations/schema/m200529_034715_create_view_homepage_dataset_type.php
@@ -4,7 +4,7 @@ class m200529_034715_create_view_homepage_dataset_type extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE VIEW homepage_dataset_type AS
+        $this->execute("CREATE OR REPLACE VIEW homepage_dataset_type AS
             SELECT type.name, count(dataset_type.id) AS count 
             FROM dataset_type, type, dataset 
             WHERE (((dataset_type.type_id = type.id) AND (dataset_type.dataset_id = dataset.id)) AND ((dataset.upload_status)::text = 'Published'::text)) 

--- a/protected/migrations/schema/m200529_035151_create_user_command_tab.php
+++ b/protected/migrations/schema/m200529_035151_create_user_command_tab.php
@@ -14,7 +14,7 @@ class m200529_035151_create_user_command_tab extends CDbMigration
             action_date timestamp without time zone,
             status character varying(32) NOT NULL);");
 
-        $this->execute("CREATE SEQUENCE user_command_id_seq
+        $this->execute("CREATE SEQUENCE IF NOT EXISTS user_command_id_seq
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE

--- a/protected/migrations/schema/m200529_035151_create_user_command_tab.php
+++ b/protected/migrations/schema/m200529_035151_create_user_command_tab.php
@@ -4,7 +4,7 @@ class m200529_035151_create_user_command_tab extends CDbMigration
 {
     public function safeUp()
     {
-        $this->execute("CREATE TABLE user_command (
+        $this->execute("CREATE TABLE IF NOT EXISTS user_command (
             id integer NOT NULL,
             action_label character varying(32) NOT NULL,
             requester_id integer NOT NULL,

--- a/sql/README.md
+++ b/sql/README.md
@@ -52,12 +52,12 @@ sudo -u postgres /usr/bin/psql -c 'create database gigadb owner gigadb'
 sudo -u postgres /usr/bin/psql -f gigadbv3_20170815_plant.backup> gigadb 
 ```
 
-## Convert production database backup to modern version of PostgreSQL [#731](https://github.com/gigascience/gigadb-website/issues/731)
+## Convert production database backup to modern version of PostgreSQL
 The `PostgreSQL` version for production database is `9.1.17`, while that for latest development work is `9.6.22`,
 So, there is a need to upgrade production database to `higher version`.
 
 Running this command would convert the production database version to `9.3+`.
-```bash
+```
 cd /gigadb-website
 
 # Spin up all gigaDB containers
@@ -86,7 +86,7 @@ cd /gigadb-website
 ### How does the script work
 Download the production database and load it into postgreSQL server using `files-url-updater` tool. You could specify the date which database backup you want to use
 by including `--date` parameter. By default, this command will download and restore the latest production database.
-```bash
+```
 cd gigadb/app/tools/files-url-updater/
 
 # Downlaod and restore the latest production database 
@@ -97,3 +97,65 @@ docker-compose run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --s
 ```
 For a detailed usage information, please
 go to [here](https://github.com/rija/gigadb-website/tree/files-url-updater-%23629/gigadb/app/tools/files-url-updater)
+
+### What to do with that text formatted database dump
+
+In this section we assume the conversion scrpit has generated the file ``gigadb/app/tools/files-url-updater/sql/gigadbv3_20210915_v9.3.25.backup``
+>Notice you will need to stop the application server before the procedure and start it again afterwad,
+otherwise psql will throw an error when trying to drop the database that there are still some users connected to the server.
+
+#### Upgrading local dev server
+
+```
+$ docker-compose stop application
+
+$ docker-compose run --rm test bash -c "psql -h database -U gigadb -d postgres -c 'drop database gigadb'"
+
+$ docker-compose run --rm test bash -c "psql -h database -U gigadb -d postgres -c 'create database gigadb'"
+
+$ docker-compose run --rm test bash -c "psql -h database -U gigadb  < /var/www/gigadb/app/tools/files-url-updater/sql/gigadbv3_20210915_v9.3.25.backup"
+
+$ docker-compose start application
+```
+
+#### upgrading staging
+
+in GitLab, click ``sd_stop_app`` button in the pipeline
+
+```
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.141.45 "psql -U gigadb -d postgres -c 'drop database gigadb'"
+
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.141.45 "psql -U postgres -d postgres -c 'create database gigadb owner gigadb'"
+
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.141.45 'psql -U gigadb' < gigadb/app/tools/files-url-updater/sql/gigadbv3_20210915_v9.3.25.backup
+```
+
+In GitLab, click ``sd_start_app`` button in pipeline
+
+
+#### upgrading live
+
+in GitLab, click ``ld_stop_app`` button in the pipeline
+
+```
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.112.113 "psql -U gigadb -d postgres -c 'drop database gigadb'"
+
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.112.113 "psql -U postgres -d postgres -c 'create database gigadb owner gigadb'"
+
+ssh -i ~/.ssh/my-aws-keys.pem  my-ec2-user@18.164.112.113 'psql -U gigadb' < gigadb/app/tools/files-url-updater/sql/gigadbv3_20210915_v9.3.25.backup
+```
+
+In GitLab, click ``ld_start_app`` button in pipeline
+
+### About database migrations
+
+After importing from a database backup as explained previously, it is advised to run the Yii database migrations
+to make sure the schema is still up-to-date. Also, any further pipeline deployment will automatically run the Yii database migrations.
+In both case, the Yii migration will fail if we don't drop existing constraints and indexes beforehand.
+This is done automatically during pipeline deployment. In a manual scenario you will need to run those commands before
+running the Yii migrations:
+```
+$ docker-compose run --rm application ./protected/yiic custommigrations dropconstraints
+$ docker-compose run --rm application ./protected/yiic custommigrations dropindexes 
+```
+


### PR DESCRIPTION
The Yii schema migrations fail to run after we import a database backup because the subjects of each migration already exist.
The solution is three fold:

* Ensure existing migrations that create tables, sequences, views only proceed if the object doesn't exist yet
* Drop all constraints before running migrations using a Yii command
* Drop all indexes before running migrations using a Yii command

Implementation:

* [x] Migration to create table only if not exists
* [x] Migration to create sequence only if not exists 
* [x] Migration to create view only if not exists
* [x] The GitLab pipeline deployment job has been updated to run the constraints dropping command before running the schema migrations.
* [x] The GitLab pipeline deployment job has been updated to run the index dropping command before running the schema migrations.
* [x] docs are updated


