### PR TITLE
Fix cicd docs

### DIFF
--- a/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-postinstall/tasks/main.yml
@@ -69,7 +69,7 @@
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
     body_format: json
     body:
-      key: "{{ gigadb_environment }}_tlsauth_ca"
+      key: "docker_tlsauth_ca"
       value: "{{ ca_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -79,7 +79,7 @@
 
 - name: Copy the CA pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_ca?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker_tlsauth_ca?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -99,7 +99,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "{{ gigadb_environment }}_tlsauth_cert"
+      key: "docker_tlsauth_cert"
       value: "{{ cert_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -109,7 +109,7 @@
 
 - name: Copy the cert pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_cert?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker_tlsauth_cert?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"
@@ -129,7 +129,7 @@
       # Content-Type: application/x-www-form-urlencoded
     body_format: json
     body:
-      key: "{{ gigadb_environment }}_tlsauth_key"
+      key: "docker_tlsauth_key"
       value: "{{ key_pem['content'] | b64decode }}"
       environment_scope: "{{ gigadb_environment }}"
     status_code:
@@ -139,7 +139,7 @@
 
 - name: Copy the key pem to GITLAB CI environment variable (subsequently)
   uri:
-    url: "{{ gitlab_url }}/variables/{{ gigadb_environment }}_tlsauth_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
+    url: "{{ gitlab_url }}/variables/docker_tlsauth_key?filter%5benvironment_scope%5d={{ gigadb_environment }}"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_private_token }}"

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -165,7 +165,7 @@
     when: always
     expire_in: 1 week
 
-.build_staging:
+build_staging:
   variables:
     GIGADB_ENV: "staging"
   extends: .pb_gigadb

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -165,7 +165,7 @@
     when: always
     expire_in: 1 week
 
-build_staging:
+.build_staging:
   variables:
     GIGADB_ENV: "staging"
   extends: .pb_gigadb

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -16,9 +16,9 @@
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem
-    - echo '$docker_tlsauth_cert' > ~/.docker/cert.pem
-    - echo '$docker_tlsauth_key' > ~/.docker/key.pem
+    - bash -c "echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # Pull production container from our private registry
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST info
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -16,12 +16,9 @@
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_key' > ~/.docker/key.pem || true"
+    - echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem
+    - echo '$docker_tlsauth_cert' > ~/.docker/cert.pem
+    - echo '$docker_tlsauth_key' > ~/.docker/key.pem
     # Pull production container from our private registry
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST info
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -12,9 +12,9 @@
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem
-    - echo '$docker_tlsauth_cert' > ~/.docker/cert.pem
-    - echo '$docker_tlsauth_key' > ~/.docker/key.pem
+    - bash -c "echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
 
 sd_top:
   variables:

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -169,12 +169,9 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # start the port 2375 for docker after ensured it's stopped (SIGKILL (137)) and removed
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST rm -f socat || true
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
@@ -197,12 +194,9 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # FUW smoke tests
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-docker-php
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-tusd-endpoint
@@ -222,12 +216,9 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # list content of assets directory
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web ls -alrt /var/www/assets
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T application ls -alrt /var/www/assets

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -12,12 +12,9 @@
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_key' > ~/.docker/key.pem || true"
+    - echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem
+    - echo '$docker_tlsauth_cert' > ~/.docker/cert.pem
+    - echo '$docker_tlsauth_key' > ~/.docker/key.pem
 
 sd_top:
   variables:
@@ -172,12 +169,12 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # start the port 2375 for docker after ensured it's stopped (SIGKILL (137)) and removed
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST rm -f socat || true
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST run --name socat -d -v /var/run/docker.sock:/var/run/docker.sock -p $remote_private_ip:2375:2375 bobrik/socat TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
@@ -200,12 +197,12 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # FUW smoke tests
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-docker-php
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T console ./yii smoke-test/check-tusd-endpoint
@@ -225,12 +222,12 @@ ld_teardown:
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$staging_tlsauth_key' > ~/.docker/key.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_ca' >  ~/.docker/ca.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_cert' > ~/.docker/cert.pem || true"
-    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$live_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = staging ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_ca' >  ~/.docker/ca.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_cert' > ~/.docker/cert.pem || true"
+    - bash -c "[[ $GIGADB_ENV = live ]] && echo '$docker_tlsauth_key' > ~/.docker/key.pem || true"
     # list content of assets directory
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web ls -alrt /var/www/assets
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T application ls -alrt /var/www/assets

--- a/ops/scripts/generate_config.sh
+++ b/ops/scripts/generate_config.sh
@@ -44,7 +44,7 @@ if ! [ -f  ./.secrets ];then
     curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${FORK_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") |.key + "=" + .value' > .fork_var
 
     echo "Retrieving variables from ${PROJECT_VARIABLES_URL}"
-    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | select(.key != "TLSAUTH_CERT") | select(.key != "TLSAUTH_KEY") | select(.key != "TLSAUTH_CA") | select(.key != "staging_tlsauth_ca") | select(.key != "staging_tlsauth_key") | select(.key != "staging_tlsauth_cert") | select(.key != "live_tlsauth_ca") | select(.key != "live_tlsauth_cert") | select(.key != "live_tlsauth_key") | select(.key != "tls_fullchain_pem") | select(.key != "tls_privkey_pem") | select(.key != "tls_chain_pem") |.key + "=" + .value' > .project_var
+    curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "${PROJECT_VARIABLES_URL}?per_page=100" | jq -r '.[] | select(.key != "ANALYTICS_PRIVATE_KEY") | select(.key != "TLSAUTH_CERT") | select(.key != "TLSAUTH_KEY") | select(.key != "TLSAUTH_CA") | select(.key != "docker_tlsauth_ca") | select(.key != "docker_tlsauth_key") | select(.key != "docker_tlsauth_cert") | select(.key != "tls_fullchain_pem") | select(.key != "tls_privkey_pem") | select(.key != "tls_chain_pem") |.key + "=" + .value' > .project_var
     cat .group_var .fork_var .project_var > .secrets && rm .group_var && rm .fork_var && rm .project_var
     echo "# Some help about this file in ops/configuration/variables/secrets-sample" >> .secrets
 fi


### PR DESCRIPTION
## Summary

For task gigascience/gigadb-website#799

* Add info about setting up SSH Key Pair in EC2 console
* Add info about setting Elastic IPs in EC2 console
* Add info about naming convention for the SSH Key Pairs and EIPs
* Change the badly named variables for storing Docker TLS client/server certificates in GitLab variables (see tables below)

The latter requires changes to several files where they were used.
In all cases, it led to simplification of the code
Update sections of the docs listing GitLab variables created by Ansible to reflect the above change.

## Variable name change

From:
| Variable's Key | Environnments | Description |
|---|---|---|
| staging_tlsauth_ca | staging | Certificate authority for staging server - this is provided by the staging server during Ansible provisioning |
| staging_tlsauth_cert | staging | Public certificate for staging server - this is provided by staging server during Ansible provisioning |
| staging_tlsauth_key  | staging | the server key for the above CA - this is provided by staging server during Ansible provisioning |
| live_tlsauth_ca | live | Certificate authority for staging server - this is provided by the live server during Ansible provisioning |
| live_tlsauth_cert | live | Public certificate for staging server - this is provided by live server during Ansible provisioning |
| live_tlsauth_key  | live | the server key for the above CA - this is provided by live server during Ansible provisioning |

To:
| Variable's Key | Environnments | Description |
|---|---|---|
| docker_tlsauth_ca | staging | Certificate authority for staging server - this is provided by the staging server during Ansible provisioning |
| docker_tlsauth_cert | staging | Public certificate for staging server - this is provided by staging server during Ansible provisioning |
| docker_tlsauth_key  | staging | the server key for the above CA - this is provided by staging server during Ansible provisioning |
| docker_tlsauth_ca | live | Certificate authority for staging server - this is provided by the live server during Ansible provisioning |
| docker_tlsauth_cert | live | Public certificate for staging server - this is provided by live server during Ansible provisioning |
| docker_tlsauth_key  | live | the server key for the above CA - this is provided by live server during Ansible provisioning |