### PR TITLE
Add portainer container service on staging and live deployment #791

### DIFF
--- a/ops/deployment/docker-compose.production-envs.yml
+++ b/ops/deployment/docker-compose.production-envs.yml
@@ -270,6 +270,20 @@ services:
       - SYS_ADMIN
     restart: unless-stopped
 
+  portainer:
+    image: portainer/portainer-ce
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    environment:
+      - VIRTUAL_HOST=${REMOTE_HOSTNAME}
+      - VIRTUAL_PORT=9009
+    ports:
+      - 9009:9000
+      - 8000:8000
+    command: -H unix:///var/run/docker.sock --admin-password $PORTAINER_BCRYPT
+
+
 networks:
   web-tier:
     driver: bridge
@@ -285,3 +299,4 @@ volumes:
   le_webrootpath:
   tempcaptcha:
   feeds:
+  portainer_data:

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -52,9 +52,15 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefileformats
+    # Spin up portainer container
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d portainer
     # Generate the web certificate for TLS termination on web container.
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm config bash -c "cp /le.staging.ini /etc/letsencrypt/cli.ini && chmod 777 /var/www/assets"
     - ./ops/scripts/setup_cert.sh
+    # Debug steps
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml ps
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml top
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml logs web
     # symlink the https configuration for web container and reload nginx (cannot be done earlier as nginx will crash if it cannot see valid web certificates)
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml exec -T web /usr/local/bin/enable_sites gigadb.$GIGADB_ENV.https
     # FUW specific steps


### PR DESCRIPTION
This PR is for [#791](https://github.com/gigascience/gigadb-website/issues/791)

### Changes in this PR
1. Include portainer service in `docker-compose.production-envs.yml`
2. Spin up the portainer container when deploying to staging and live servers.

### Results on staging server
```
[centos@ip-172-31-10-159 ~]$ docker ps
CONTAINER ID   IMAGE                                                                                  COMMAND                  CREATED          STATUS          PORTS                                                                                  NAMES
b6fbf101c676   portainer/portainer-ce                                                                 "/portainer -H unix:…"   10 seconds ago   Up 8 seconds    0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9009->9000/tcp, :::9009->9000/tcp   kencho51-gigadb-website_portainer_1
cc020b40555a   registry.gitlab.com/gigascience/forks/kencho51-gigadb-website/production_web:staging   "/usr/local/bin/enab…"   31 seconds ago   Up 29 seconds   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp               kencho51-gigadb-website_web_1
c2cee89f7ff8   registry.gitlab.com/gigascience/forks/kencho51-gigadb-website/production_app:staging   "docker-php-entrypoi…"   41 seconds ago   Up 39 seconds   9000/tcp                                                                               kencho51-gigadb-website_application_1

[centos@ip-172-31-10-159 ~]$ curl -I localhost:9009
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=31536000
Content-Length: 23180
Content-Type: text/html; charset=utf-8
Last-Modified: Thu, 26 Aug 2021 22:17:01 GMT
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block
Date: Fri, 24 Sep 2021 04:12:01 GMT
```
### Results on live server
```
[centos@ip-172-31-7-227 ~]$ docker ps
CONTAINER ID   IMAGE                                                                               COMMAND                  CREATED          STATUS          PORTS                                                                                  NAMES
f57f10c3f7df   portainer/portainer-ce                                                              "/portainer -H unix:…"   3 seconds ago    Up 2 seconds    0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9009->9000/tcp, :::9009->9000/tcp   kencho51-gigadb-website_portainer_1
5ab7854878a5   registry.gitlab.com/gigascience/forks/kencho51-gigadb-website/production_web:live   "/usr/local/bin/enab…"   33 seconds ago   Up 32 seconds   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp               kencho51-gigadb-website_web_1
bff10f029c9a   registry.gitlab.com/gigascience/forks/kencho51-gigadb-website/production_app:live   "docker-php-entrypoi…"   43 seconds ago   Up 42 seconds   9000/tcp                                                                               kencho51-gigadb-website_application_1
[centos@ip-172-31-7-227 ~]$ curl -I localhost:9009
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=31536000
Content-Length: 23180
Content-Type: text/html; charset=utf-8
Last-Modified: Thu, 26 Aug 2021 22:17:01 GMT
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block
Date: Fri, 24 Sep 2021 04:21:23 GMT
```