### PR TITLE
Enable setting AWS region for terraform provisioning

### DIFF
--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -275,7 +275,7 @@ sd_gigadb:
 
 #### AWS-CLI
 
-TODO: link up to @pli888's aws docs
+See [awsdocs/awscli.md](awsdocs/awscli.md)
 
 #### AWS dashboard
 
@@ -286,9 +286,8 @@ There are two activities to perform on the AWS dashboard's EC2 console prior to 
 
 Those resources needs to be globally unique in the same AWS acccount, so you need to follow the naming convention below:
 
-1. For Elastic IPS: ``eip-ape1-<environment>-<IAM Role Username>-gigadb``
-1. For SSH Key pair: any name of your choosing that's unique and contains your IAM Role Username
-
+1. For Elastic IPS: ``eip-<application>-<environment>-<IAM Role Username>``, e.g: ``eip-gigadb-staging-Rija``
+1. For SSH Key pair: ``aws-<application>-<AWS region>-<IAM Role Username>.pem``, e.g: ``aws-gigadb-eu-west-3-Rija.pem``
 The private part of the SSH Key pair needs to be dowloaded to your developer machine in the ``~/.ssh`` directory and with 
 permission set to ``600``.
 
@@ -391,6 +390,17 @@ so we can run ``terraform`` and ``ansible-playbook`` commands from those directo
 In particular, the ``ops/scripts/tf_init.sh`` script will write in a ``.init_vars`` file the answer to the prompted value, so that they are not asked
 again in subsequent runs. ``ops/scripts/ansible_init.sh`` will also source that file.
 
+###### The list of files that will be created or placed in those directories during deployment:
+
+| name | description | used by |
+| --- | --- | --- |
+| ansible.properties | created by ``provisioner_init.sh``, holds variables assignment used by Ansible to configure deployed application| ansible-playbook | 
+| getIAMUserNameToJSON.sh | copied by ``provisioner_init.sh`` | terraform |
+| output/ | created by ``ansible-playbook`` to store a copy of Docker certs | docker |
+| playbook.yml | copied by ``provisioner_init.sh`` | ansible-playbook | 
+| terraform.tf | copied by ``provisioner_init.sh`` | terraform |
+| terraform.tfvars | created by ``provisioner_init.sh`` to hold Terraform variables assigments | terraform | 
+
 #### Ansible
 
 [Ansible](https://www.ansible.com) is used to install the EC2 instance 
@@ -436,22 +446,6 @@ However, the connection parameters (like SSH keys) are variables we need to supp
 The machines controlled by Ansible are defined in a [`hosts`](https://github.com/gigascience/gigadb-website/blob/develop/ops/infrastructure/inventories/hosts)
 file which lists the host machines connection details. Our file is located at `ops/infrastructure/inventories/hosts` and here is the current content annotated:
 ```
-[name_gigadb_server_staging] # host name for staging deployment, the name is a concatenation of AWS tag key and value attached to the EC2 instance
-
-# do not add any IP address here as it is dynamically managed using terraform-inventory
-
-[name_gigadb_server_live] # host name for live deployment, the name is a concatenation of AWS tags attached to the EC2 instance
-
-# do not add any IP address here as it is dynamically managed using terraform-inventory
-
-[name_bastion_server_staging] # host name for staging deployment, the name is a concatenation of AWS tag key and value attached to the EC2 instance
-
-# do not add any IP address here as it is dynamically managed using terraform-inventory
-
-[name_bastion_server_live] # host name for live deployment, the name is a concatenation of AWS tags attached to the EC2 instance
-
-# do not add any IP address here as it is dynamically managed using terraform-inventory
-
 [all:vars] # host variables needed by Ansible to configure software and services. Most have their value pulled from ansible.properties created with the ansible_init.sh script
 
 gitlab_url = "https://gitlab.com/api/v4/projects/{{ lookup('ini', 'gitlab_project type=properties file=ansible.properties') | urlencode | regex_replace('/','%2F') }}"
@@ -470,17 +464,6 @@ fuw_db_password = "{{ lookup('ini', 'fuw_db_password type=properties file=ansibl
 fuw_db_database = "{{ lookup('ini', 'fuw_db_database type=properties file=ansible.properties') }}"
 
 backup_file = "{{ lookup('ini', 'backup_file type=properties file=ansible.properties') }}"
-```
-
->Note that the header **[name_gigadb_server_staging]** must match the "Name" tag associated to the AWS EC2 resource defined in ``ops/infrastructure/modules/aws-instance/aws-instance.tf`` for the environment of interest (here ``staging``):
-
-```
-tags = {
-    Name = "gigadb_server_${var.deployment_target}",
-    Hosting = "ec2-as1-t2m-centos"
-    Environment = "staging"
-    Owner = "Rija"
- }
 ```
 
 >**Note:** host names in Ansible must be made of alphanumerical and underscore characters only. Although Terraform and AWS don't have that limitation, the Name tag needs to follow it so the connection between Terraform and Ansible can be made.
@@ -534,6 +517,18 @@ Provision the EC2 instance using Ansible:
 $ cd ops/infrastructure/envs/staging
 $ ansible-playbook -i ../../inventories dockerhost_playbook.yml
 ```
+
+>Note that that **name_gigadb_server_staging_<IAMUser>** must match the "Name" tag associated to the AWS EC2 resource defined in ``ops/infrastructure/modules/aws-instance/aws-instance.tf`` for the environment of interest (here ``staging``):
+
+```
+  tags = {
+    Name = "gigadb_server_${var.deployment_target}_${var.owner}",
+    System = "t3_micro-centos7",
+  }
+```
+
+>**Note:** host names in Ansible must be made of alphanumerical and underscore characters only. Although Terraform and AWS don't have that limitation, the Name tag needs to follow it so the connection between Terraform and Ansible can be made.
+
 
 > Since an elastic IP address is being used, you might need to delete the entry
 in the `~/.ssh/known_hosts` file associated with the elastic IP address if this

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -523,7 +523,7 @@ $ ansible-playbook -i ../../inventories dockerhost_playbook.yml
 ```
   tags = {
     Name = "gigadb_server_${var.deployment_target}_${var.owner}",
-    System = "t3_micro-centos7",
+    System = "t3_micro-centos8",
   }
 ```
 

--- a/docs/awsdocs/policy-ec2.md
+++ b/docs/awsdocs/policy-ec2.md
@@ -54,7 +54,12 @@ when using the AWS management console.
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "ec2:Region": "ap-east-1"
+                    "ec2:Region": [
+                        "ap-east-1",
+                        "ap-northeast-1",
+                        "ap-southeast-1",
+                        "eu-west-3"
+                    ]
                 },
                 "ForAllValues:StringLike": {
                     "ec2:InstanceType": [

--- a/ops/infrastructure/inventories/hosts
+++ b/ops/infrastructure/inventories/hosts
@@ -1,9 +1,3 @@
-[name_gigadb_server_staging]
-
-# do not add any IP address here as it is dynamically managed using terraform-inventory
-
-[name_gigadb_server_live]
-
 # do not add any IP address here as it is dynamically managed using terraform-inventory
 
 [name_bastion_server_staging]

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -69,7 +69,7 @@ data "aws_ami" "centos" {
     values = ["hvm"]
   }
 
-  owners = ["aws-marketplace"]
+  owners = ["125523088429"]
 }
 
 resource "aws_instance" "docker_host" {

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -81,7 +81,7 @@ resource "aws_instance" "docker_host" {
 
   tags = {
     Name = "gigadb_server_${var.deployment_target}_${var.owner}",
-    System = "t3_micro-centos7",
+    System = "t3_micro-centos8",
   }
 
   root_block_device {

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -56,9 +56,24 @@ resource "aws_security_group" "docker_host_sg" {
    }
 }
 
+data "aws_ami" "centos" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS ENA *"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["aws-marketplace"]
+}
 
 resource "aws_instance" "docker_host" {
-  ami = "ami-0b197b1f02309cb3c"
+  ami = data.aws_ami.centos.id
   instance_type = "t3.micro"
   vpc_security_group_ids = [aws_security_group.docker_host_sg.id]
   key_name = var.key_name
@@ -66,7 +81,7 @@ resource "aws_instance" "docker_host" {
 
   tags = {
     Name = "gigadb_server_${var.deployment_target}_${var.owner}",
-    System = "t3_micro-centos8",
+    System = "t3_micro-centos7",
   }
 
   root_block_device {

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -61,7 +61,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS ENA *"]
+    values = ["CentOS 8.4.2105 x86_64"]
   }
 
   filter {

--- a/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
+++ b/ops/infrastructure/modules/bastion-aws-instance/bastion-aws-instance.tf
@@ -25,8 +25,24 @@ resource "aws_security_group" "bastion_sg" {
    }
 }
 
+data "aws_ami" "centos" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CentOS 8.4.2105 x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["125523088429"]
+}
+
 resource "aws_instance" "bastion" {
-  ami = "ami-0b197b1f02309cb3c"  # Centos 8
+  ami = data.aws_ami.centos.id
   associate_public_ip_address = true
   instance_type = "t3.micro"
   vpc_security_group_ids = [aws_security_group.bastion_sg.id]

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -42,6 +42,10 @@ data "external" "callerUserName" {
   program = ["${path.module}/getIAMUserNameToJSON.sh"]
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 provider "aws" {
   region     =  var.aws_region
   default_tags {  # These tags are copied into child modules and resources
@@ -69,7 +73,7 @@ module "vpc" {
   cidr = "10.99.0.0/18"
   
   # VPC spans all the availability zones in region
-  azs = ["ap-east-1a", "ap-east-1b", "ap-east-1c"]
+  azs = data.aws_availability_zones.available.names
 
   # We can add one or more subnets into each AZ. A subnet is required to launch
   # AWS resources into a VPC and is a range of IP addresses. Each subnet has a 

--- a/ops/scripts/tf_init.sh
+++ b/ops/scripts/tf_init.sh
@@ -63,6 +63,10 @@ if [ -z $backup_file ];then
   read -p "You need to specify a backup file created by the files-url-updater tool: " backup_file
 fi
 
+if [ -z $AWS_REGION ];then
+  read -p "You need to specify an AWS region: " AWS_REGION
+fi
+
 # url encode gitlab project
 encoded_gitlab_project=$(echo $gitlab_project | sed -e 's/\//%2F/g')
 
@@ -84,6 +88,7 @@ key_name=$(echo $aws_ssh_key | rev | cut -d"/" -f 1 | rev | cut -d"." -f 1)
 # create the terraform variables file (must be named terraform.tfvars for terraform to recognise it automatically)
 echo "deployment_target = \"$target_environment\"" > terraform.tfvars
 echo "key_name = \"$key_name\"" >> terraform.tfvars
+echo "aws_region = \"$AWS_REGION\"" >> terraform.tfvars
 # create an environment variable file for this script and for ansible_init.sh
 echo "gitlab_project=$gitlab_project" > .init_env_vars
 echo "GITLAB_USERNAME=$GITLAB_USERNAME" >> .init_env_vars


### PR DESCRIPTION
* Update aws-instance.tf to stop hard-coding AMI id and implement AMI lookup as the AMI Id is specific to a region.
* Update terraform.tf to add aws_region as an input variable
* Update ``tf_init.sh`` to prompt operator for an AWS region and save the value in ``terraform.tfvars``
* Update the CI/CD documentation
* Update EC2 policy to enable choosing of AWS region amongst a canned list 

>Note 1: the naming convention for EIP has changed so to not hardcode region: ``eip-<application>-<environment>-<IAM Role Username>``, e.g: ``eip-gigadb-staging-Rija``

>Note 2: The EC2 policy allows use of following AWS regions:
> * ap-east-1 (Hong Kong)
> * ap-northeast-1 (Tokyo)
> * ap-southeast-1 (Singapore)
> * eu-west-3 (Paris)