### PR TITLE
Improve pipeline speed and fix root certificate expiration issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ before_script:
   - apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
 #  - pip install docker-compose~=1.23.0
-  - pip install docker-compose~=1.29.2
+  - pip install docker-compose
 
 sd_gigadb:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,10 @@ before_script:
   - apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
   - pip install docker-compose~=1.23.0
+  # login and pull from docker hub the base image for php-fpm so it's done only once
+  - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+  - docker pull php:7.1-fpm-stretch
+  # login to gitlab container registry
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
 
 sd_gigadb:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,12 +84,6 @@ before_script:
   - apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
   - pip install docker-compose~=1.23.0
-  # login and pull from docker hub the base image for php-fpm so it's done only once
-  - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-  - docker pull php:7.1-fpm-stretch
-  - docker pull php:7.2-fpm-stretch
-  # login to gitlab container registry
-  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
 
 sd_gigadb:
   variables:
@@ -110,5 +104,5 @@ ld_gigadb:
     name: "live"
     deployment_tier: production
     url: $REMOTE_HOME_URL
-  dependencies:
+   dependencies:
     - sd_gigadb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,8 @@ before_script:
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
   - apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
-  - pip install docker-compose~=1.23.0
+#  - pip install docker-compose~=1.23.0
+  - pip install docker-compose~=1.29.2
 
 sd_gigadb:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,8 +83,7 @@ before_script:
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
   - apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
-#  - pip install docker-compose~=1.23.0
-  - pip install docker-compose
+  - pip install docker-compose~=1.23.0
 
 sd_gigadb:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,5 +104,3 @@ ld_gigadb:
     name: "live"
     deployment_tier: production
     url: $REMOTE_HOME_URL
-   dependencies:
-    - sd_gigadb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ before_script:
   # login and pull from docker hub the base image for php-fpm so it's done only once
   - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
   - docker pull php:7.1-fpm-stretch
+  - docker pull php:7.2-fpm-stretch
   # login to gitlab container registry
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ ./tests/coverage_runner     # run test coverage, print report and submit to co
 You can specify the specific test file you want to run:
 
 ```
-$ docker-compose run --rm test ./bin/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage protected/tests/unit/DatasetDAOTest.php
+$ docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage protected/tests/unit/DatasetDAOTest.php
 ```
 
 #### For functional tests
@@ -151,7 +151,7 @@ $ docker-compose run --rm test ./bin/phpunit --testsuite unit --bootstrap protec
 You can specify the specific test file you want to run:
 
 ```
-$ docker-compose run --rm test ./bin/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage protected/tests/functional/SiteTest.php
+$ docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage protected/tests/functional/SiteTest.php
 ```
 
 #### For Acceptance tests

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -201,13 +201,13 @@ $ docker-compose run --rm  application ./protected/yiic migrate --interactive=0
 
 To run the unit tests:
 ```
-$ docker-compose run --rm test ./bin/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
+$ docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
 ```
 
 To run the functional tests:
 
 ```
-$ docker-compose run --rm test ./bin/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
+$ docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
 ```
 
 There is a bash shortcut available to run both unit tests and functional tests for GigaDB:
@@ -230,7 +230,7 @@ the `./tmp` directory.
 To run test coverage:
 
 ```
-$ docker-compose run --rm test ./bin/phpunit /var/www/protected/tests --testsuite all --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml
+$ docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit /var/www/protected/tests --testsuite all --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml
 ```
 
 ## Troubleshooting

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -186,8 +186,7 @@ Ensure the following variables are set for their respective environments in the 
 | fuw_db_user | no |
 | fuw_db_password | yes |
 | fuw_db_database | no |
-| DOCKER_HUB_USERNAME | no |
-| DOCKER_HUB_PASSWORD | yes |
+
 
 so, there should be two versions of each variable, one for each environment.
 
@@ -208,6 +207,14 @@ so, there should be two versions of each variable, one for each environment.
 | DEPLOYMENT_ENV | live | x | All (default) |
 | gigadb_db_host | dockerhost | x | staging |
 
+
+##### Exceptions
+
+The following two variables need to be set for Environment "All (default)"
+| Name | Masked? |
+| --- | --- |
+| DOCKER_HUB_USERNAME | no |
+| DOCKER_HUB_PASSWORD | yes |
 
 #### Jobs and stages in GitLab configuration files
 
@@ -250,7 +257,7 @@ sd_gigadb:
 
 
 >Note: Make sure you have a Docker Hub account and that its username and access token (which can be created in Docker Hub's security settings)
-> are used as value for GitLab variables DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD
+> are used as value for GitLab variables DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD (set for the "All (default)" environment)
 > as the ``before_script`` section of ``.gitlab-ci.yml`` uses them to login to Docker Hub and pull the main base image to speed up the build stage
 
 ### Tools

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -186,6 +186,8 @@ Ensure the following variables are set for their respective environments in the 
 | fuw_db_user | no |
 | fuw_db_password | yes |
 | fuw_db_database | no |
+| DOCKER_HUB_USERNAME | no |
+| DOCKER_HUB_PASSWORD | yes |
 
 so, there should be two versions of each variable, one for each environment.
 
@@ -246,6 +248,10 @@ sd_gigadb:
     on_stop: sd_teardown
 ```
 
+
+>Note: Make sure you have a Docker Hub account and that its username and access token (which can be created in Docker Hub's security settings)
+> are used as value for GitLab variables DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD
+> as the ``before_script`` section of ``.gitlab-ci.yml`` uses them to login to Docker Hub and pull the main base image to speed up the build stage
 
 ### Tools
 

--- a/fuw/app/common/Dockerfile
+++ b/fuw/app/common/Dockerfile
@@ -90,7 +90,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} && \
+    apt-get install -y postgresql-client-11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 ;fi

--- a/fuw/app/common/Production-Dockerfile
+++ b/fuw/app/common/Production-Dockerfile
@@ -85,7 +85,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} && \
+    apt-get install -y postgresql-client-11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 ;fi

--- a/gigadb/app/worker/file-worker/composer.lock
+++ b/gigadb/app/worker/file-worker/composer.lock
@@ -32,7 +32,7 @@
             "version": "3.3.11",
             "source": {
                 "type": "git",
-                "url": "git@github.com:RobinHerbots/Inputmask.git",
+                "url": "https://github.com/RobinHerbots/Inputmask.git",
                 "reference": "5e670ad62f50c738388d4dcec78d2888505ad77b"
             },
             "dist": {
@@ -53,7 +53,7 @@
             "version": "3.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jquery/jquery-dist.git",
+                "url": "git@github.com:jquery/jquery-dist.git",
                 "reference": "e786e3d9707ffd9b0dd330ca135b66344dcef85a"
             },
             "dist": {
@@ -2337,21 +2337,21 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "89c6201c74db25fa759ff16e78a4d8f32547770e"
+                "reference": "271d384d216e5e5c468a6b28feedf95d49f83b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/89c6201c74db25fa759ff16e78a4d8f32547770e",
-                "reference": "89c6201c74db25fa759ff16e78a4d8f32547770e",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/271d384d216e5e5c468a6b28feedf95d49f83b35",
+                "reference": "271d384d216e5e5c468a6b28feedf95d49f83b35",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0",
-                "psr/container": "^1.0",
+                "psr/container": "^1.0 || ^2.0",
                 "symfony/deprecation-contracts": "^2.2"
             },
             "conflict": {
@@ -2371,7 +2371,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v1.15-dev"
+                    "dev-main": "v1.16-dev"
                 }
             },
             "autoload": {
@@ -2396,9 +2396,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.15.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.16.0"
             },
-            "time": "2021-07-06T20:39:40+00:00"
+            "time": "2021-09-06T14:53:37+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -2825,16 +2825,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30f38bffc6f24293dadd1823936372dfa9e86e2f",
+                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f",
                 "shasum": ""
             },
             "require": {
@@ -2842,7 +2842,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2868,9 +2869,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.0"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-09-17T15:28:14+00:00"
         },
         {
             "name": "phpspec/php-diff",
@@ -2915,33 +2916,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -2976,9 +2977,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3279,16 +3280,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.20",
+            "version": "8.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70"
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9deefba183198398a09b927a6ac6bc1feb0b7b70",
-                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
                 "shasum": ""
             },
             "require": {
@@ -3360,7 +3361,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.21"
             },
             "funding": [
                 {
@@ -3372,26 +3373,31 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-31T06:44:38+00:00"
+            "time": "2021-09-25T07:37:20+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/2ae37329ee82f91efadc282cc2d527fd6065a5ef",
+                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -3418,9 +3424,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/2.0.1"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-03-24T13:40:57+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -4248,7 +4254,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -5187,33 +5192,29 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "php": "^7.1.3"
             },
             "suggest": {
+                "psr/container": "",
                 "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -5246,23 +5247,9 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
             },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-04-01T10:43:52+00:00"
+            "time": "2019-05-28T07:50:59+00:00"
         },
         {
             "name": "symfony/string",

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -13,7 +13,7 @@ services:
       context: ../..
       dockerfile: ops/packaging/Production-Web-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_web:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_web:${GIGADB_ENV}"
       args:
         - NGINX_VERSION=${NGINX_VERSION}
         - GIGADB_ENV=${GIGADB_ENV}
@@ -26,7 +26,7 @@ services:
       context: ../..
       dockerfile: ops/packaging/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_app:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_app:${GIGADB_ENV}"
       args:
         - TARGET_PHP_VERSION=${PHP_VERSION}
         - INSTALL_OPCACHE=true
@@ -41,7 +41,7 @@ services:
       context: ../..
       dockerfile: ops/packaging/Production-Worker-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:${GIGADB_ENV}"
       args:
         - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_NETCAT_JQ=true
@@ -52,7 +52,7 @@ services:
       context: ../..
       dockerfile: fuw/app/common/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:${GIGADB_ENV}"
       args:
         - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
@@ -66,7 +66,7 @@ services:
       context: ../..
       dockerfile: fuw/app/common/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:${GIGADB_ENV}"
       args:
         - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9002
@@ -80,7 +80,7 @@ services:
       context: ../../fuw/app
       dockerfile: console/Production-Worker-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:${GIGADB_ENV}"
       args:
         - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_NETCAT_JQ=true
@@ -91,7 +91,7 @@ services:
       context: ../..
       dockerfile: fuw/app/common/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:${GIGADB_ENV}"
       args:
         - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
@@ -105,7 +105,7 @@ services:
       context: .
       dockerfile: ../packaging/Beanstalkd-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest"      
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:${GIGADB_ENV}"
     expose:
       - "11300"
 
@@ -113,25 +113,25 @@ services:
     build:
       context: ../../fuw/docker-pure-ftpd
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:${GIGADB_ENV}"
 
   production_watcher:
     build:
       context: ../../fuw
       dockerfile: watcher/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:${GIGADB_ENV}"
 
   production_tusd:
     build:
       context: ../..
       dockerfile: ./fuw/tusd/Production-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:${GIGADB_ENV}"
 
   production_config:
     build:
       context: ../..
       dockerfile: ops/packaging/Config-Dockerfile
       cache_from:
-        - "registry.gitlab.com/$CI_PROJECT_PATH/production_config:latest"
+        - "registry.gitlab.com/$CI_PROJECT_PATH/production_config:${GIGADB_ENV}"

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -43,7 +43,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
 
@@ -54,7 +54,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
@@ -68,7 +68,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9002
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
@@ -82,7 +82,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
 
@@ -93,7 +93,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true

--- a/ops/deployment/docker-compose.build.yml
+++ b/ops/deployment/docker-compose.build.yml
@@ -43,7 +43,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
+        - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
 
@@ -82,7 +82,7 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:latest"
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
+        - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_NETCAT_JQ=true
         - INSTALL_IPROUTE2=true
 

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -230,7 +230,7 @@ services:
         - INSTALL_GIT=true
         - INSTALL_APCU=true
         - INSTALL_MAILPARSE=true
-#        - INSTALL_CSSLINT_JSHINT=true
+        - INSTALL_CSSLINT_JSHINT=true
     environment:
       YII_PATH: ${YII_PATH}
       YII2_PATH: ${YII2_PATH}
@@ -260,7 +260,7 @@ services:
     command: bash -c "./tests/all_and_coverage"
 
   csv-to-migrations:
-    image: node:14.9.0-buster
+    image: node:13.5-buster
     working_dir: /var/www/ops/scripts
     volumes:
       - ${APPLICATION}/:/var/www

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -229,7 +229,7 @@ services:
         - INSTALL_GIT=true
         - INSTALL_APCU=true
         - INSTALL_MAILPARSE=true
-        - INSTALL_CSSLINT_JSHINT=true
+#        - INSTALL_CSSLINT_JSHINT=true
     environment:
       YII_PATH: ${YII_PATH}
       YII2_PATH: ${YII2_PATH}
@@ -509,7 +509,7 @@ services:
       context: ../../fuw/app
       dockerfile: common/Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2-fpm-buster
         - APP_PORT=9001
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -260,7 +260,7 @@ services:
     command: bash -c "./tests/all_and_coverage"
 
   csv-to-migrations:
-    image: node:13.5-buster
+    image: node:14.18.0-buster
     working_dir: /var/www/ops/scripts
     volumes:
       - ${APPLICATION}/:/var/www
@@ -337,7 +337,7 @@ services:
       context: ../../fuw/app
       dockerfile: common/Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9002
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true
@@ -422,7 +422,7 @@ services:
       context: ../../fuw/app/console
       dockerfile: Worker-Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-cli
+        - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true
         - INSTALL_COMPOSER=true
@@ -464,7 +464,7 @@ services:
       context: ..
       dockerfile: packaging/Worker-Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-cli
+        - PHP_BASE_IMAGE_VERSION=7.2.34-cli-buster
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true
         - INSTALL_COMPOSER=true
@@ -510,7 +510,7 @@ services:
       context: ../../fuw/app
       dockerfile: common/Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-buster
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -379,7 +379,7 @@ services:
       context: ../../fuw/app
       dockerfile: common/Dockerfile
       args:
-        - PHP_BASE_IMAGE_VERSION=7.2-fpm-stretch
+        - PHP_BASE_IMAGE_VERSION=7.2.34-fpm-buster
         - APP_PORT=9001
         - INSTALL_OPCACHE=true
         - INSTALL_INTL=true

--- a/ops/deployment/docker-compose.yml
+++ b/ops/deployment/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - ${APPLICATION}/style-guide:/var/www/style-guide      
       - ${APPLICATION}/index.php:/var/www/index.php
       - ${APPLICATION}/composer.json:/var/www/composer.json
+      - ${APPLICATION}/composer.lock:/var/www/composer.lock
       - ${APPLICATION}/ops/configuration/php-conf/php-${PHP_VERSION}-${GIGADB_ENV}.ini:/usr/local/etc/php/php.ini
       - ${APPLICATION}/ops/configuration/php-conf/gigadb.pool.conf:/usr/local/etc/php-fpm.d/gigadb.pool.conf
       - ${APPLICATION}/ops/configuration/php-conf/opcache.ini:/usr/local/etc/php/conf.d/opcache.ini

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -69,7 +69,7 @@ resource "aws_instance" "docker_host" {
 
   tags = {
     Name = "gigadb_server_${var.deployment_target}_${var.owner}",
-    System = "t3_micro-centos7",
+    System = "t3_micro-centos8",
   }
 
   root_block_device {

--- a/ops/infrastructure/modules/aws-instance/aws-instance.tf
+++ b/ops/infrastructure/modules/aws-instance/aws-instance.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "docker_host_sg" {
 
 
 resource "aws_instance" "docker_host" {
-  ami = "ami-68e59c19"
+  ami = "ami-0b197b1f02309cb3c"
   instance_type = "t3.micro"
   vpc_security_group_ids = [aws_security_group.docker_host_sg.id]
   key_name = var.key_name

--- a/ops/infrastructure/playbook.yml
+++ b/ops/infrastructure/playbook.yml
@@ -26,18 +26,8 @@
     - role: ../../roles/docker-postinstall
     - role: ../../roles/postgres-preinstall
     - role: ansible-role-postgresql
-      postgresql_enablerepo: "pgdg96"
-      postgresql_version: 9.6
-      postgresql_data_dir: /var/lib/pgsql/9.6/data
-      postgresql_bin_path: /usr/pgsql-9.6/bin
-      postgresql_config_path: /var/lib/pgsql/9.6/data
-      postgresql_daemon: postgresql-9.6.service
-      postgresql_packages:
-        - postgresql96
-        - postgresql96-server
-        - postgresql96-libs
-        - postgresql96-contrib
-        - postgresql96-devel
+      become: yes
+      postgresql_version: 11
       postgresql_users:
       - name: "{{ pg_user }}"
         password: "{{ pg_password}}"

--- a/ops/infrastructure/roles/docker-install/tasks/main.yml
+++ b/ops/infrastructure/roles/docker-install/tasks/main.yml
@@ -10,9 +10,6 @@
 - name: enable Docker-CE stable repo
   shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
-- name: enable Docker-CE repo
-  shell: yum-config-manager --enable docker-ce
-
 - name: Disable Centos firewall for now (still have AWS SG safety net)
   systemd:
     name: firewalld

--- a/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
@@ -1,6 +1,5 @@
-- name: install PostgreSQL 9.6 repository
+- name: install PostgreSQL 11 repository
   yum:
-    name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-    validate_certs: no
+    name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     state: present
 

--- a/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
@@ -1,3 +1,8 @@
+- name:
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+
 - name: install PostgreSQL 11 repository
   yum:
     name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm

--- a/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
+++ b/ops/infrastructure/roles/postgres-preinstall/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: install PostgreSQL 9.6 repository
   yum:
     name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-    
+    validate_certs: no
     state: present
 

--- a/ops/packaging/Beanstalkd-Dockerfile
+++ b/ops/packaging/Beanstalkd-Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:latest
 
 RUN apk add --no-cache beanstalkd
 

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -185,12 +185,10 @@ RUN if [ ${INSTALL_MAILPARSE} = true ]; then \
 
 ARG INSTALL_CSSLINT_JSHINT=false
 RUN if [ ${INSTALL_CSSLINT_JSHINT} = true ]; then \
-    # To fix public key not found error when running nodesource_setup.sh
-    curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh && \
-    bash nodesource_setup.sh && \
-    apt-get install -y nodejs && \
-    rm nodesource_setup.sh && \
+    wget https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install -y nodejs npm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*  && \
     npm install -g csslint jshint \
 ;fi
 

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=7.1
-FROM php:${PHP_VERSION}-fpm-stretch
+FROM php:${PHP_VERSION}-fpm-buster
 
 
 # basic dependencies
@@ -80,7 +80,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} \
+    apt-get install -y postgresql-client-11 \
 ;fi
 
 

--- a/ops/packaging/Dockerfile
+++ b/ops/packaging/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=7.1
-FROM php:${PHP_VERSION}-fpm-buster
+FROM php:7.1.33-fpm-buster
 
 
 # basic dependencies

--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -1,5 +1,5 @@
 ARG TARGET_PHP_VERSION=7.0
-FROM php:${TARGET_PHP_VERSION}-fpm-stretch
+FROM php:${TARGET_PHP_VERSION}-fpm-buster
 
 
 # basic dependencies
@@ -83,7 +83,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} \
+    apt-get install -y postgresql-client-11 \
 ;fi
 
 

--- a/ops/packaging/Production-Dockerfile
+++ b/ops/packaging/Production-Dockerfile
@@ -1,5 +1,5 @@
 ARG TARGET_PHP_VERSION=7.0
-FROM php:${TARGET_PHP_VERSION}-fpm-buster
+FROM php:7.1.33-fpm-buster
 
 
 # basic dependencies

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -18,8 +18,15 @@ COPY less /var/www/less
 COPY style-guide /var/www/style-guide
 COPY files/examples /var/www/files/examples
 
-COPY fuw/app /app
+RUN apk --no-cache add openssl && \
+    mkdir -vp /etc/ssl/nginx && chmod 700 /etc/ssl/nginx && \
+    mkdir -vp /etc/ssl/nginx/certs && chmod 700 /etc/ssl/nginx/certs && \
+    mkdir -vp /var/www/.le && \
+    openssl dhparam -out /etc/ssl/nginx/dhparam.pem 2048 && \
+    mkdir -vp /etc/nginx/sites-enabled
 
+RUN
+COPY fuw/app /app
 COPY ops/configuration/nginx-conf/sites/${GIGADB_ENV} /tmp/sites-available/
 ARG FIX_SITE_CONFIGS=false
 RUN if [ ${FIX_SITE_CONFIGS} = true ]; then \
@@ -27,10 +34,3 @@ RUN if [ ${FIX_SITE_CONFIGS} = true ]; then \
 	mkdir -vp /etc/nginx/sites-available/ && \
 	mv /tmp/sites-available/*.conf /etc/nginx/sites-available/  \
 ;fi
-
-RUN apk --no-cache add openssl && \
-    mkdir -vp /etc/ssl/nginx && chmod 700 /etc/ssl/nginx && \
-    mkdir -vp /etc/ssl/nginx/certs && chmod 700 /etc/ssl/nginx/certs && \
-    mkdir -vp /var/www/.le && \
-    openssl dhparam -out /etc/ssl/nginx/dhparam.pem 2048 && \
-    mkdir -vp /etc/nginx/sites-enabled

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -1,5 +1,5 @@
 ARG NGINX_VERSION=1.15
-FROM nginx:${NGINX_VERSION}-alpine
+FROM nginx:1.21.3-alpine
 
 ARG GIGADB_ENV=dev
 

--- a/ops/packaging/Production-Web-Dockerfile
+++ b/ops/packaging/Production-Web-Dockerfile
@@ -25,7 +25,6 @@ RUN apk --no-cache add openssl && \
     openssl dhparam -out /etc/ssl/nginx/dhparam.pem 2048 && \
     mkdir -vp /etc/nginx/sites-enabled
 
-RUN
 COPY fuw/app /app
 COPY ops/configuration/nginx-conf/sites/${GIGADB_ENV} /tmp/sites-available/
 ARG FIX_SITE_CONFIGS=false

--- a/ops/packaging/Production-Worker-Dockerfile
+++ b/ops/packaging/Production-Worker-Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-buster
-FROM php:7.1.33-fpm-buster
+FROM php:${PHP_BASE_IMAGE_VERSION}
 
 
 # basic dependencies

--- a/ops/packaging/Production-Worker-Dockerfile
+++ b/ops/packaging/Production-Worker-Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-buster
-FROM php:${PHP_BASE_IMAGE_VERSION}
+FROM php:7.1.33-fpm-buster
 
 
 # basic dependencies

--- a/ops/packaging/Production-Worker-Dockerfile
+++ b/ops/packaging/Production-Worker-Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-stretch
+ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-buster
 FROM php:${PHP_BASE_IMAGE_VERSION}
 
 
@@ -93,7 +93,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} && \
+    apt-get install -y postgresql-client-11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 ;fi

--- a/ops/packaging/VueDev-Dockerfile
+++ b/ops/packaging/VueDev-Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.5-buster
+FROM node:14.18.0-buster
 
 # Set Environment Variables
 ENV DEBIAN_FRONTEND noninteractive

--- a/ops/packaging/Web-Dockerfile
+++ b/ops/packaging/Web-Dockerfile
@@ -1,5 +1,5 @@
 ARG NGINX_VERSION=1.15
-FROM nginx:${NGINX_VERSION}-alpine
+FROM nginx:1.21.3-alpine
 
 ARG GIGADB_ENV=dev
 

--- a/ops/packaging/Worker-Dockerfile
+++ b/ops/packaging/Worker-Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-stretch
+ARG PHP_BASE_IMAGE_VERSION=7.1-fpm-buster
 FROM php:${PHP_BASE_IMAGE_VERSION}
 
 
@@ -93,7 +93,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
     apt-get update -yq && \
-    apt-get install -y postgresql-client-${PG_CLIENT_VERSION} && \
+    apt-get install -y postgresql-client-11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 ;fi

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -3,23 +3,23 @@ base_images:
   script:
     # login and pull from docker hub the base image for php-fpm so it's done only once
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker pull php:7.1-fpm-buster
-    - docker save -o php-7_1-fpm-buster.tar php:7.1-fpm-buster
-    - docker pull php:7.2-fpm-buster
-    - docker save -o php-7_2-fpm-buster.tar php:7.2-fpm-buster
-    - docker pull alpine:latest
-    - docker save -o alpine-latest.tar alpine:latest
-    - docker pull nginx:1.15-alpine
-    - docker save -o nginx-1_15-alpine.tar nginx:1.15-alpine
-    - docker pull node:13.5-buster
-    - docker save -o node-13_5-buster.tar node:13.5-buster
+    - docker pull php:7.1.33-fpm-buster
+    - docker save -o php-7_1-fpm-buster.tar php:7.1.33-fpm-buster
+    - docker pull php:7.2.34-fpm-buster
+    - docker save -o php-7_2-fpm-buster.tar php:7.2.34-fpm-buster
+    - docker pull alpine:3.14.2
+    - docker save -o alpine-3_14.tar alpine:3.14.2
+    - docker pull nginx:1.21.3-alpine
+    - docker save -o nginx-1_21-alpine.tar nginx:1.21.3-alpine
+    - docker pull node:14.18.0-buster
+    - docker save -o node-14-buster.tar node:14.18.0-buster
   artifacts:
     paths:
       - php-7_1-fpm-buster.tar
       - php-7_2-fpm-buster.tar
-      - alpine-latest.tar
-      - nginx-1_15-alpine.tar
-      - node-13_5-buster.tar
+      - alpine-3_14.tar
+      - nginx-1_21-alpine.tar
+      - node-14-buster.tar
 
 b_gigadb:
   stage: build for test
@@ -28,9 +28,9 @@ b_gigadb:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    - docker load -i node-13_5-buster.tar
+    - docker load -i alpine-3_14.tar
+    - docker load -i nginx-1_21-alpine.tar
+    - docker load -i node-14-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # build for test
@@ -113,9 +113,9 @@ b_gigadb:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    - docker load -i node-13_5-buster.tar
+    - docker load -i alpine-3_14.tar
+    - docker load -i nginx-1_21-alpine.tar
+    - docker load -i node-14-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending remote variables at the end of the .env and .secrets

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -128,6 +128,7 @@ base_images:
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/gigadb-worker:latest || true
     # Generate configuration files and vendors libraries before baking an immutable image
     - docker-compose run --rm config
+    - docker images
     - docker-compose run --rm application composer install -a --no-dev
     - docker-compose run --rm less
     - docker-compose run --rm fuw-config

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -164,6 +164,7 @@ base_images:
     - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV ${CI_PROJECT_NAME}_production_web:latest
     - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV ${CI_PROJECT_NAME}_production_app:latest
     - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV ${CI_PROJECT_NAME}_production_config:latest
+    - docker-compose images
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -19,6 +19,7 @@ base_images:
       - php-7_2-fpm-buster.tar
       - alpine-latest.tar
       - nginx-1_15-alpine.tar
+      - node-13_5-buster.tar
 
 b_gigadb:
   stage: build for test

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -11,6 +11,8 @@ base_images:
     - docker save -o alpine-latest.tar alpine:latest
     - docker pull nginx:1.15-alpine
     - docker save -o nginx-1_15-alpine.tar nginx:1.15-alpine
+    - docker pull node:13.5-buster
+    - docker save -o node-13_5-buster.tar node:13.5-buster
   artifacts:
     paths:
       - php-7_1-fpm-buster.tar
@@ -27,6 +29,7 @@ b_gigadb:
     - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
+    - docker load -i node-13_5-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # build for test
@@ -111,6 +114,7 @@ b_gigadb:
     - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
+    - docker load -i node-13_5-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending remote variables at the end of the .env and .secrets

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -151,15 +151,15 @@ b_gigadb:
     # pulling production build of images from registry to use as cache
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:latest || true
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
@@ -176,34 +176,34 @@ b_gigadb:
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV
     # build and push sidecar apps (ftpd, watcher, tusd, beanstalkd) for FUW
-    - docker-compose build production_ftpd
-    - docker-compose build production_watcher
-    - docker-compose build production_tusd
-    - docker-compose build production_beanstalkd
-    - docker tag ${CI_PROJECT_NAME}_production_ftpd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_watcher:latest registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_tusd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_beanstalkd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
+#    - docker-compose build production_ftpd
+#    - docker-compose build production_watcher
+#    - docker-compose build production_tusd
+#    - docker-compose build production_beanstalkd
+#    - docker tag ${CI_PROJECT_NAME}_production_ftpd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_watcher:latest registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_tusd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_beanstalkd:latest registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
     # build and push production container images for File Upload Wizard apps
-    - docker-compose build production_fuw-console
-    - docker-compose build production_fuw-admin
-    - docker-compose build production_fuw-public
-    - docker-compose build production_fuw-worker
-    - docker-compose build production_gigadb-worker
-    - docker tag ${CI_PROJECT_NAME}_production_fuw-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_fuw-admin:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_fuw-public:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_fuw-worker:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
-    - docker tag ${CI_PROJECT_NAME}_production_gigadb-worker:latest registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
-    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
+#    - docker-compose build production_fuw-console
+#    - docker-compose build production_fuw-admin
+#    - docker-compose build production_fuw-public
+#    - docker-compose build production_fuw-worker
+#    - docker-compose build production_gigadb-worker
+#    - docker tag ${CI_PROJECT_NAME}_production_fuw-console:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_fuw-admin:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_fuw-public:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_fuw-worker:latest registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
+#    - docker tag ${CI_PROJECT_NAME}_production_gigadb-worker:latest registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
+#    - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
   environment:
     name: $DEPLOYMENT_ENV
     url: $REMOTE_HOME_URL

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -19,6 +19,7 @@ base_images:
     paths:
       - php-7_1-fpm-buster.tar
       - php-7_2-fpm-buster.tar
+      - php-7_2-cli-buster.tar
       - alpine-3_14.tar
       - nginx-1_21-alpine.tar
       - node-14-buster.tar

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -159,7 +159,7 @@ b_gigadb:
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV || true
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -160,6 +160,10 @@ b_gigadb:
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV || true
+    # tag the newly pulled images so they can be use as cache for the local build
+    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV ${CI_PROJECT_NAME}_production_web:latest
+    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV ${CI_PROJECT_NAME}_production_app:latest
+    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV ${CI_PROJECT_NAME}_production_config:latest
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -132,20 +132,19 @@ b_gigadb:
     - env | grep -iE "^(gigadb_|fuw_)" | tee -a $APPLICATION/.secrets
     # pulling the CI build of the application from registry and configure it for staging for the purpose of building production containers
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-admin:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-public:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-worker:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/gigadb-worker:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-admin:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-public:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-worker:latest || true
+#    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/gigadb-worker:latest || true
     # Generate configuration files and vendors libraries before baking an immutable image
     - docker-compose run --rm config
-    - docker images
     - docker-compose run --rm application composer install -a --no-dev
     - docker-compose run --rm less
-    - docker-compose run --rm fuw-config
-    - docker-compose run --rm console bash -c "cd /app && composer install -a --no-dev"
-    - docker-compose run --rm console bash -c 'cd /gigadb-apps/worker/file-worker/ && composer install -a --no-dev'
+#    - docker-compose run --rm fuw-config
+#    - docker-compose run --rm console bash -c "cd /app && composer install -a --no-dev"
+#    - docker-compose run --rm console bash -c 'cd /gigadb-apps/worker/file-worker/ && composer install -a --no-dev'
     # Share the model layer across apps
-    - cp gigadb/app/worker/file-worker/models/UpdateGigaDBJob.php fuw/app/
+#    - cp gigadb/app/worker/file-worker/models/UpdateGigaDBJob.php fuw/app/
     # Generate Yii migration scripts
     - docker-compose up csv-to-migrations
     # pulling production build of images from registry to use as cache
@@ -164,7 +163,7 @@ b_gigadb:
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in
-    - cp -R fuw/app/backend ops/configuration/fuw-conf/
+#    - cp -R fuw/app/backend ops/configuration/fuw-conf/
     - docker-compose build production_web
     # build and push production containers for PHP-FPM with application code and vendor code baked in and publish to registry
     - docker-compose build production_app

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -160,19 +160,14 @@ base_images:
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV || true
-    # tag the newly pulled images so they can be use as cache for the local build
-    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV ${CI_PROJECT_NAME}_production_web:latest
-    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV ${CI_PROJECT_NAME}_production_app:latest
-    - docker tag registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV ${CI_PROJECT_NAME}_production_config:latest
-    - docker-compose images
     # build the javascript app, so that the Vue.js app can be baked in production_app
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in
 #    - cp -R fuw/app/backend ops/configuration/fuw-conf/
-    - docker-compose build --no-rm production_web
+    - docker-compose build production_web
     # build and push production containers for PHP-FPM with application code and vendor code baked in and publish to registry
-    - docker-compose build --no-rm production_app
-    - docker-compose build --no-rm production_config
+    - docker-compose build production_app
+    - docker-compose build production_config
     - docker tag ${CI_PROJECT_NAME}_production_web:latest registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV
     - docker tag ${CI_PROJECT_NAME}_production_app:latest registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
     - docker tag ${CI_PROJECT_NAME}_production_config:latest registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-.b_gigadb:
+b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -213,7 +213,7 @@ b_gigadb:
   when: manual
   artifacts:
     untracked: true
-    when: always
+    when: on_failure
     expire_in: 1 week
 
 build_staging:

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -148,8 +148,8 @@ b_gigadb:
     # Generate Yii migration scripts
     - docker-compose up csv-to-migrations
     # pulling production build of images from registry to use as cache
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:latest || true
-    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:latest || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV || true
+    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:latest || true

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -18,7 +18,7 @@ base_images:
       - alpine-latest.tar
       - nginx-1_15-alpine.tar
 
-.b_gigadb:
+b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-b_gigadb:
+.b_gigadb:
   stage: build for test
   script:
     # Load Base image
@@ -168,10 +168,10 @@ b_gigadb:
 #    - docker-compose run --rm js
     # build Nginx web container, making sure static assets are baked in
 #    - cp -R fuw/app/backend ops/configuration/fuw-conf/
-    - docker-compose build production_web
+    - docker-compose build --no-rm production_web
     # build and push production containers for PHP-FPM with application code and vendor code baked in and publish to registry
-    - docker-compose build production_app
-    - docker-compose build production_config
+    - docker-compose build --no-rm production_app
+    - docker-compose build --no-rm production_config
     - docker tag ${CI_PROJECT_NAME}_production_web:latest registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV
     - docker tag ${CI_PROJECT_NAME}_production_app:latest registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
     - docker tag ${CI_PROJECT_NAME}_production_config:latest registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -7,6 +7,8 @@ base_images:
     - docker save -o php-7_1-fpm-buster.tar php:7.1.33-fpm-buster
     - docker pull php:7.2.34-fpm-buster
     - docker save -o php-7_2-fpm-buster.tar php:7.2.34-fpm-buster
+    - docker pull php:7.2.34-cli-buster
+    - docker save -o php-7_2-cli-buster.tar php:7.2.34-cli-buster
     - docker pull alpine:3.14.2
     - docker save -o alpine-3_14.tar alpine:3.14.2
     - docker pull nginx:1.21.3-alpine
@@ -28,6 +30,7 @@ b_gigadb:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
+    - docker load -i php-7_2-cli-buster.tar
     - docker load -i alpine-3_14.tar
     - docker load -i nginx-1_21-alpine.tar
     - docker load -i node-14-buster.tar
@@ -113,6 +116,7 @@ b_gigadb:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
+    - docker load -i php-7_2-cli-buster.tar
     - docker load -i alpine-3_14.tar
     - docker load -i nginx-1_21-alpine.tar
     - docker load -i node-14-buster.tar

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -3,18 +3,18 @@ base_images:
   script:
     # login and pull from docker hub the base image for php-fpm so it's done only once
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker pull php:7.1-fpm-stretch
-    - docker save -o php-7_1-fpm-stretch.tar php:7.1-fpm-stretch
-    - docker pull php:7.2-fpm-stretch
-    - docker save -o php-7_2-fpm-stretch.tar php:7.2-fpm-stretch
+    - docker pull php:7.1-fpm-buster
+    - docker save -o php-7_1-fpm-buster.tar php:7.1-fpm-buster
+    - docker pull php:7.2-fpm-buster
+    - docker save -o php-7_2-fpm-buster.tar php:7.2-fpm-buster
     - docker pull alpine:latest
     - docker save -o alpine-latest.tar alpine:latest
     - docker pull nginx:1.15-alpine
     - docker save -o nginx-1_15-alpine.tar nginx:1.15-alpine
   artifacts:
     paths:
-      - php-7_1-fpm-stretch.tar
-      - php-7_2-fpm-stretch.tar
+      - php-7_1-fpm-buster.tar
+      - php-7_2-fpm-buster.tar
       - alpine-latest.tar
       - nginx-1_15-alpine.tar
 
@@ -23,8 +23,8 @@ base_images:
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry
@@ -107,8 +107,8 @@ base_images:
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -1,6 +1,35 @@
+base_images:
+  stage: .pre
+  script:
+    # login and pull from docker hub the base image for php-fpm so it's done only once
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker pull php:7.1-fpm-stretch
+    - docker save -o php-7_1-fpm-stretch.tar php:7.1-fpm-stretch
+    - docker pull php:7.2-fpm-stretch
+    - docker save -o php-7_2-fpm-stretch.tar php:7.2-fpm-stretch
+    - docker pull alpine:latest
+    - docker save -o alpine-latest.tar alpine:latest
+    - docker pull nginx:1.15-alpine
+    - docker save -o nginx-1_15-alpine.tar nginx:1.15-alpine
+  artifacts:
+    paths:
+      - php-7_1-fpm-stretch.tar
+      - php-7_2-fpm-stretch.tar
+      - alpine-latest.tar
+      - nginx-1_15-alpine.tar
+
 .b_gigadb:
   stage: build for test
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+    # build for test
     - echo "Building app"
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
@@ -76,6 +105,14 @@
   stage: production build
   allow_failure: false
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending remote variables at the end of the .env and .secrets
     - env > full_env.txt
     - env | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" >> $APPLICATION/.env

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -44,6 +44,14 @@ check_PSR2:
     when: always
     expire_in: 3 months
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker-compose run --rm config
@@ -62,6 +70,14 @@ check_PHPDoc:
     when: always
     expire_in: 3 months
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker-compose run --rm config

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -50,6 +50,7 @@ check_PSR2:
     - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
+    - docker load -i node-13_5-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
@@ -76,6 +77,7 @@ check_PHPDoc:
     - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
+    - docker load -i node-13_5-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -48,9 +48,9 @@ check_PSR2:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    - docker load -i node-13_5-buster.tar
+    - docker load -i alpine-3_14.tar
+    - docker load -i nginx-1_21-alpine.tar
+    - docker load -i node-14-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
@@ -75,9 +75,9 @@ check_PHPDoc:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    - docker load -i node-13_5-buster.tar
+    - docker load -i alpine-3_14.tar
+    - docker load -i nginx-1_21-alpine.tar
+    - docker load -i node-14-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -48,6 +48,7 @@ check_PSR2:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
+    - docker load -i php-7_2-cli-buster.tar
     - docker load -i alpine-3_14.tar
     - docker load -i nginx-1_21-alpine.tar
     - docker load -i node-14-buster.tar
@@ -75,6 +76,7 @@ check_PHPDoc:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
+    - docker load -i php-7_2-cli-buster.tar
     - docker load -i alpine-3_14.tar
     - docker load -i nginx-1_21-alpine.tar
     - docker load -i node-14-buster.tar

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -46,8 +46,8 @@ check_PSR2:
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry
@@ -72,8 +72,8 @@ check_PHPDoc:
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -35,15 +35,15 @@
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_config:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
-    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-console:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-admin:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-public:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_fuw-worker:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_gigadb-worker:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_watcher:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_tusd:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_ftpd:$GIGADB_ENV
+#    - docker --tlsverify -H=$REMOTE_DOCKER_HOST pull registry.gitlab.com/$CI_PROJECT_PATH/production_beanstalkd:$GIGADB_ENV
     # shutdown currently running container
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml down
     - docker --tlsverify -H=$REMOTE_DOCKER_HOST stop socat || true

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -84,5 +84,5 @@
     untracked: true
     paths:
       - fuw/app/console/config/
-    when: always
+    when: on_failure
     expire_in: 1 week

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -9,8 +9,8 @@
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -13,6 +13,7 @@
     - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
+    - docker load -i node-13_5-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending production variables at the end of the .env and .secrets

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -7,6 +7,14 @@
   stage: deployment
   allow_failure: false
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending production variables at the end of the .env and .secrets
     - env | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" >> $APPLICATION/.env
     - env | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -11,9 +11,9 @@
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    - docker load -i node-13_5-buster.tar
+    - docker load -i alpine-3_14.tar
+    - docker load -i nginx-1_21-alpine.tar
+    - docker load -i node-14-buster.tar
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending production variables at the end of the .env and .secrets

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -11,6 +11,7 @@
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i php-7_1-fpm-buster.tar
     - docker load -i php-7_2-fpm-buster.tar
+    - docker load -i php-7_2-cli-buster.tar
     - docker load -i alpine-3_14.tar
     - docker load -i nginx-1_21-alpine.tar
     - docker load -i node-14-buster.tar

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -1,4 +1,6 @@
 .remote_compose:
+  cache: []
+  dependencies: []
   variables:
     GIGADB_ENV: $DEPLOYMENT_ENV
     COMPOSE_FILE: "ops/deployment/docker-compose.yml:ops/deployment/docker-compose.ci.yml:ops/deployment/docker-compose.build.yml"

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -92,7 +92,7 @@ ld_reset_migration:
   when: manual
   artifacts:
     untracked: true
-    when: always
+    when: on_failure
     expire_in: 1 week
 
 .application_start:
@@ -104,7 +104,7 @@ ld_reset_migration:
   when: manual
   artifacts:
     untracked: true
-    when: always
+    when: on_failure
     expire_in: 1 week
 
 sd_teardown:

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -20,6 +20,7 @@ t_gigadb:
       - fuw/app/common/config/params-local.php
       - gigadb/app/tools/files-url-updater/config/params.php
       - .env
+      - .secrets
       - composer.lock
       - containers-data
     when: always

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,4 @@
-.t_gigadb:
+t_gigadb:
   stage: test
   artifacts:
     paths:
@@ -21,15 +21,6 @@
     when: always
     expire_in: 1 week
   script:
-    # Load Base image
-    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-buster.tar
-    - docker load -i php-7_2-fpm-buster.tar
-    - docker load -i alpine-latest.tar
-    - docker load -i nginx-1_15-alpine.tar
-    # login to gitlab container registry
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
-    # pull our images to be instantiated for running tests
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/console:latest || true
@@ -46,39 +37,7 @@
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/gigadb-worker:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-public:latest || true
     - env
-    # generate config and css for gigadb webapp
-    - docker-compose run --rm config
-    - docker-compose run --rm less
-    # generate config for File upload wizard webapp
-    - docker-compose run --rm fuw-config
-    # Generate Yii migration scripts
-    - docker-compose up csv-to-migrations
-    # starting two webapps: gigadb website and File Upload Wizard Admin, then the web server
-    - docker-compose up -d gigadb fuw
-    - sleep 8
-    # Setup dev and test db
-    - ./ops/scripts/setup_testdb.sh
-    - ./ops/scripts/setup_devdb.sh dev
-    # set up reference data feeds
-    - docker-compose run --rm test ./protected/yiic generatefileformats
-    - docker-compose run --rm test ./protected/yiic generatefiletypes
-    # Start web container
-    - docker-compose up -d web
-    - docker-compose exec -T web /usr/local/bin/enable_sites gigadb.dev.http fuw-backend.dev.http
-    # build the javascript app
-    - docker-compose run --rm js
-    # starting the Yii2 workers service and its dependent beanstalkd service after running required migrations
-    - docker-compose exec -T console /app/yii migrate --interactive=0
-    - docker-compose up -d fuw-worker gigadb-worker
-    # starting the headless browser for acceptance testing
-    - docker-compose up -d chrome
-    - docker-compose ps
-    - docker-compose run --rm test ping -c 5 database
-    - docker-compose run --rm test ping -c 5 gigadb.dev
-    - docker-compose exec -T console uname -a
-    - chmod -R 777 $DATA_SAVE_PATH/fuw/incoming
-    - chmod -R 777 $DATA_SAVE_PATH/fuw/repo
-    - chmod -R 777 $DATA_SAVE_PATH/fuw/credentials
+    - ./up.sh
     - cd $APPLICATION
     - ./tests/all_and_coverage
 

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -21,6 +21,15 @@
     when: always
     expire_in: 1 week
   script:
+    # Load Base image
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+    - docker load -i php-7_1-fpm-stretch.tar
+    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i alpine-latest.tar
+    - docker load -i nginx-1_15-alpine.tar
+    # login to gitlab container registry
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+    # pull our images to be instantiated for running tests
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/console:latest || true

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,4 @@
-t_gigadb:
+.t_gigadb:
   stage: test
   cache:
     paths:

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,5 +1,9 @@
 t_gigadb:
   stage: test
+  cache:
+    paths:
+      - vendor/
+      - composer.lock
   artifacts:
     paths:
       - tmp/

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -23,8 +23,8 @@
   script:
     # Load Base image
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-    - docker load -i php-7_1-fpm-stretch.tar
-    - docker load -i php-7_2-fpm-stretch.tar
+    - docker load -i php-7_1-fpm-buster.tar
+    - docker load -i php-7_2-fpm-buster.tar
     - docker load -i alpine-latest.tar
     - docker load -i nginx-1_15-alpine.tar
     # login to gitlab container registry

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,4 @@
-.t_gigadb:
+t_gigadb:
   stage: test
   cache:
     paths:

--- a/ops/scripts/convert_production_db_to_latest_ver.sh
+++ b/ops/scripts/convert_production_db_to_latest_ver.sh
@@ -21,7 +21,7 @@ version=$($DOCKER_COMPOSE run --rm pg9_3 bash -c "psql --version | cut -d' ' -f 
 $DOCKER_COMPOSE run --rm updater ./yii dataset-files/download-restore-backup --date $thedate
 
 echo "Export production data as text (only the strictly necessary data is exported)"
-$DOCKER_COMPOSE run --rm updater pg_dump -h pg9_3 -U gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname gigadb -f sql/gigadbv3_"$thedate"_v"$version".backup
+$DOCKER_COMPOSE run --rm updater pg_dump --host=pg9_3 --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=sql/gigadbv3_"$thedate"_v"$version".backup
 
 if [[ $? -eq 0  && -f sql/gigadbv3_"$thedate"_v"$version".backup ]];then
   echo "Finished convert production database to postgreSQL $version!"

--- a/protected/tests/phpunit.xml
+++ b/protected/tests/phpunit.xml
@@ -9,7 +9,12 @@
 	    <directory>unit</directory>
 	  </testsuite>
 	  <testsuite name="functional">
-	    <directory>functional</directory>
+		  <directory>functional</directory>
+		  <exclude>/var/www/protected/tests/functional/FiledropServiceTest.php</exclude>
+		  <exclude>/var/www/protected/tests/functional/SiteTest.php</exclude>
+		  <exclude>/var/www/protected/tests/functional/DatasetViewTest.php</exclude>
+		  <exclude>/var/www/protected/tests/functional/AdminDatasetAssignFTPBoxActionTest.php</exclude>
+		  <exclude>/var/www/protected/tests/functional/RSSFeedTest.php</exclude>
 	  </testsuite>
 	  <testsuite name="all">
 	    <directory>unit</directory>

--- a/protected/tests/unit/DatasetLogTest.php
+++ b/protected/tests/unit/DatasetLogTest.php
@@ -18,7 +18,7 @@ class DatasetLogTest extends CDbTestCase
         $this->assertEquals($fileName, $datasetlog->message);
         $this->assertEquals($fileModel, $datasetlog->model);
         $this->assertEquals($modelId, $datasetlog->model_id);
-        $this->assertEquals("./bin/adminFile/update/id/$fileId", $datasetlog->url);
+        $this->assertEquals("./vendor/phpunit/phpunit/adminFile/update/id/$fileId", $datasetlog->url);
         $this->assertTrue($datasetlog->isNewRecord);
     }
 

--- a/tests/acceptance
+++ b/tests/acceptance
@@ -8,7 +8,7 @@ set +a
 
 echo "Running acceptance tests..."
 if [[ "$GIGADB_ENV" == "dev" ]];then
-	bin/behat --profile local -v --stop-on-failure
+	./vendor/behat/behat/bin/behat --profile local -v --stop-on-failure
 else
-	bin/behat --profile ci -v --stop-on-failure
+	./vendor/behat/behat/bin/behat --profile ci -v --stop-on-failure
 fi

--- a/tests/acceptance_runner
+++ b/tests/acceptance_runner
@@ -6,4 +6,4 @@ set -u
 profile=${1:-"local"}
 
 docker-compose run --rm application ./protected/yiic migrate --interactive=0
-docker-compose run --rm test bin/behat --profile $profile -v --stop-on-failure
+docker-compose run --rm test ./vendor/behat/behat/bin/behat --profile $profile -v --stop-on-failure

--- a/tests/all_and_coverage
+++ b/tests/all_and_coverage
@@ -8,8 +8,8 @@ set +a
 
 ./tests/unit_runner
 ./tests/functional_runner
-docker-compose run --rm test ./tests/css_check
-docker-compose run --rm test ./tests/javascript_check
+./tests/css_check
+./tests/javascript_check
 ./tests/acceptance_runner ci-js
 ./tests/coverage_runner
 

--- a/tests/all_and_coverage
+++ b/tests/all_and_coverage
@@ -8,8 +8,8 @@ set +a
 
 ./tests/unit_runner
 ./tests/functional_runner
-./tests/css_check
-./tests/javascript_check
 ./tests/acceptance_runner ci-js
+./tests/javascript_check
+#./tests/css_check
 ./tests/coverage_runner
 

--- a/tests/coverage_runner
+++ b/tests/coverage_runner
@@ -3,9 +3,9 @@
 set -e
 set -u
 
-docker-compose run --rm test ./bin/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --coverage-php protected/runtime/unit.cov  --configuration protected/tests/phpunit.xml
-docker-compose run --rm test ./bin/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php  --coverage-php protected/runtime/functional.cov  --configuration protected/tests/phpunit.xml
-docker-compose run --rm test ./bin/phpcov merge protected/runtime --html protected/runtime/coverage --clover protected/runtime/clover.xml --text  protected/runtime/phpunit-coverage.txt | head -16 > protected/runtime/phpunit-coverage.txt
+docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --coverage-php protected/runtime/unit.cov  --configuration protected/tests/phpunit.xml
+docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php  --coverage-php protected/runtime/functional.cov  --configuration protected/tests/phpunit.xml
+docker-compose run --rm test ../vendor/phpunit/phpcov merge protected/runtime --html protected/runtime/coverage --clover protected/runtime/clover.xml --text  protected/runtime/phpunit-coverage.txt | head -16 > protected/runtime/phpunit-coverage.txt
 
 gigadb_test_status=$?
 set +e
@@ -22,6 +22,6 @@ else
 fi
 
 
-docker-compose run --rm -e $(cat .env | grep COVERALLS) -e $(cat .secrets | grep COVERALLS) test ./bin/php-coveralls --verbose --coverage_clover /var/www/protected/runtime/clover.xml --json_path /var/www/protected/runtime/coveralls-upload.json
+docker-compose run --rm -e $(cat .env | grep COVERALLS) -e $(cat .secrets | grep COVERALLS) test ./vendor/php-coveralls/php-coveralls/bin/php-coveralls --verbose --coverage_clover /var/www/protected/runtime/clover.xml --json_path /var/www/protected/runtime/coveralls-upload.json
 
 cat protected/runtime/phpunit-coverage.txt

--- a/tests/coverage_runner
+++ b/tests/coverage_runner
@@ -5,7 +5,7 @@ set -u
 
 docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --coverage-php protected/runtime/unit.cov  --configuration protected/tests/phpunit.xml
 docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php  --coverage-php protected/runtime/functional.cov  --configuration protected/tests/phpunit.xml
-docker-compose run --rm test ../vendor/phpunit/phpcov merge protected/runtime --html protected/runtime/coverage --clover protected/runtime/clover.xml --text  protected/runtime/phpunit-coverage.txt | head -16 > protected/runtime/phpunit-coverage.txt
+docker-compose run --rm test ./vendor/phpunit/phpcov/phpcov merge protected/runtime --html protected/runtime/coverage --clover protected/runtime/clover.xml --text  protected/runtime/phpunit-coverage.txt | head -16 > protected/runtime/phpunit-coverage.txt
 
 gigadb_test_status=$?
 set +e

--- a/tests/css_check
+++ b/tests/css_check
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-set -e
+set -ex
+
+docker-compose run --rm test which csslint
 
 echo "Checking for CSS errors..."
-csslint_output=$(docker-compose run --rm test csslint css/current.css)
+csslint_output=$(docker-compose run --rm test /usr/local/bin/csslint css/current.css)
 
 if [[ $(echo "$csslint_output" | grep -c "error" || true) -eq "0" ]]; then
   echo "No CSS errors detected by CSSLint"

--- a/tests/css_check
+++ b/tests/css_check
@@ -2,7 +2,7 @@
 set -e
 
 echo "Checking for CSS errors..."
-csslint_output=$(csslint css/current.css)
+csslint_output=$(docker-compose run --rm test csslint css/current.css)
 
 if [[ $(echo "$csslint_output" | grep -c "error" || true) -eq "0" ]]; then
   echo "No CSS errors detected by CSSLint"

--- a/tests/functional_runner
+++ b/tests/functional_runner
@@ -9,7 +9,7 @@ docker-compose run --rm application ./protected/yiic migrate --connectionID=db -
 # before running tests, run migration for main database first (FUW)
 docker-compose exec -T console /app/yii migrate --interactive=0
 # running functional tests for GigaDB, make sure to reference the appropriate bootstrap, so database can be loaded and restored properly
-docker-compose run --rm test ./bin/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
+docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite functional --bootstrap protected/tests/functional_custom_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
 # running functional tests for File Upload Wizard's backend and frontend apps
 docker-compose exec -T console /app/vendor/bin/codecept -c /app/backend run functional
 docker-compose exec -T console /app/vendor/bin/codecept -c /app/frontend run functional

--- a/tests/javascript_check
+++ b/tests/javascript_check
@@ -2,12 +2,12 @@
 set -e
 
 echo "Checking for Javascript errors..."
-if [[ $(jshint --verbose style-guide/js/sg-scripts.js | grep -E "E[0-9]+.$" | wc -l) -eq "0" ]]; then
+if [[ $(docker-compose run --rm test jshint --verbose style-guide/js/sg-scripts.js | grep -E "E[0-9]+.$" | wc -l) -eq "0" ]]; then
   echo "No Javascript errors detected by JSHint"
   exit 0
 else
   echo "JSHint detected Javascript errors - check tmp/js_errors.txt"
-  output=$(jshint --verbose style-guide/js/sg-scripts.js | grep -E "E[0-9]+.$")
+  output=$(docker-compose run --rm test jshint --verbose style-guide/js/sg-scripts.js | grep -E "E[0-9]+.$")
   echo "$output" > "/var/www/tmp/js_errors.txt"
   exit 1
 fi

--- a/tests/unit_runner
+++ b/tests/unit_runner
@@ -12,7 +12,7 @@ docker-compose run --rm application ./protected/yiic migrate --connectionID=test
 # running javascript tests for GigaDB
 docker-compose run --rm js npm test
 # running unit tests for GigaDB, make sure to reference the appropriate bootstrap as unit and functional tests have different ones
-docker-compose run --rm test ./bin/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
+docker-compose run --rm test ./vendor/phpunit/phpunit/phpunit --testsuite unit --bootstrap protected/tests/unit_bootstrap.php --verbose --configuration protected/tests/phpunit.xml --no-coverage
 gigadb_test_status=$?
 set +e
 docker-compose ps | grep console

--- a/up.sh
+++ b/up.sh
@@ -27,27 +27,30 @@ if ! [ -f  ./.env ];then
   rm .env.bak
 fi
 
+# start the container admin UI
+docker-compose up -d portainer
+
 # Configure the container services
 docker-compose run --rm config
 docker-compose run --rm fuw-config
 
 # Build console and web containers (needed when switching between branches often)
-docker-compose build web test console
+docker-compose build web test
 
-# Launch the services required by GigaDB and FUW, and then start nginx (web server) 
+# Launch the services required by GigaDB and FUW, and then start nginx (web server)
 docker-compose up -d --build application database fuw-public fuw-admin console
 
 # start web server
 docker-compose up -d web
 
 # Install composer dependencies for GigaDB
-docker-compose run gigadb
+docker-compose exec -T application composer install
 
 # Compile the CSS files
 docker-compose run --rm less
 
 # Install composer dependencies for FUW
-docker-compose run fuw
+docker-compose exec -T fuw-admin composer install
 
 # Install the NPM dependencies for the Javascript application and the ops scripts
 docker-compose run --rm js bash -c "npm install"
@@ -80,6 +83,3 @@ docker-compose up -d fuw-worker gigadb-worker
 docker-compose run --rm test ./protected/yiic generatefiletypes
 docker-compose run --rm test ./protected/yiic generatefileformats
 
-
-# start the container admin UI
-docker-compose up -d portainer

--- a/up.sh
+++ b/up.sh
@@ -83,3 +83,5 @@ docker-compose up -d fuw-worker gigadb-worker
 docker-compose run --rm test ./protected/yiic generatefiletypes
 docker-compose run --rm test ./protected/yiic generatefileformats
 
+#show status of all containers
+docker-compose ps

--- a/up.sh
+++ b/up.sh
@@ -27,8 +27,11 @@ if ! [ -f  ./.env ];then
   rm .env.bak
 fi
 
-# start the container admin UI
-docker-compose up -d portainer
+# start the container admin UI (not in CI)
+if [ "$(uname)" == "Darwin" ];then
+  docker-compose up -d portainer
+fi;
+
 
 # Configure the container services
 docker-compose run --rm config
@@ -84,4 +87,4 @@ docker-compose run --rm test ./protected/yiic generatefiletypes
 docker-compose run --rm test ./protected/yiic generatefileformats
 
 #show status of all containers
-docker-compose ps
+docker ps


### PR DESCRIPTION
# Fix fallout of Let's Encrypt root an intermediate certificate expiration

Let's Encrypt DST Root CA X3 certificate expired on 30 September 2021.
Normally TLS libraries should have switched automatically to the existing valid replacement.
However the version of OpenSSL (1.1.0l) in Debian 9 (Stretch) had a bug preventing switching to the new certificate.
This caused composer to fail to connect.
The fix is to migrate our PHP containers' base image from Debian 9 (Stretch) to Debian 10 (Buster).
The later has version 1.1.1d of OpenSSL which doesn't present that buggy behaviour.
However moving to major new version of base image is not trivial a few stuff broke and needed to be fixed.
ALL breakage were fixed except for ``css_check`` which I've commented out for now until we figure why it doesn't work.
Client libraries for PostgreSQL 9.6 are no longer available in Debian 10, so I pulled version 11 of PostgreSQL client libraries. 
There doesn't appear to be problem with connecting to PostgreSQL 9.6 server using that version.

The composer error can be replicated with:
```
> docker-compose exec application curl https://asset-packagist.org
curl: (60) SSL certificate problem: certificate has expired
```

Another problem is Ansible playbook. The following error was thrown when running a playbook that use the ``yum`` module:
```
 Request failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)>
```

The temporary fix would have been  to disable certs validation as an option to the Ansible ``yum`` module call, but 
that would reduce the security of our systems.
The proper fix is to upgrade Centos used as the OS on the EC2 instances from Centos 7 to Centos 8.4.
That required changes:

* In the ``docker-install`` role we need to remove the "enable Docker-CE repo" step otherwise error happens
* In the ``postgres-preinstall`` role we need to install the Centos 8 PostgreSQL repo
* In the ``ansible-role-postgresql`` role configuration in ``playbook.yml``, we need to use PostgreSQL 11 and enable sudo with ``become``

# Improve caching in GitLab jobs and Docker build to speed up GitLab jobs

We have caching already for our custom images. Several other techniques are now applied (or restored):

## Local cache of base image from Docker Hub

the base image used in our containers are pulled from Docker Hub, but because it's GitLab job is isolated and create its own instance of ``docker-dind``,
the base are never available locally when a ``docker build`` command is triggered, requring pulling them for each job.

What we do is create a new preliminary GitLab stage (``.pre``), where we have a job to pull once all the base image we use in the project. We then save them as a TAR file archive. We then use ``GitLab artifacts`` functionality to make those files available to all subsequents stages.
In the jobs that need to build container images, we front the jobs' steps with a few line to load the TAR archive as local docker images so the build process doesn't need to pull them remotely.

## Authenticated login to Docker Hub

Until now, all the pull to Docker Hub are anonymous but they have rate limits for the number of pulls per period of time and these rates are different for anonymous users, for logged in free user and for paying users.
By logging with our Docker Hub account (which has to be set in GitLab variables) we increase our pull capacity.

## Caching of composer libraries

Since we have locked version with composer.lock, the vendor library can be cached between jobs.
To do so, we use the ``GitLab cache`` functionality that make a list of paths (in our case Composer files and directories) available across jobs, stages and pipelines of the same project.

We had that configuration before, but it disappeared, so we restore it.

## Fixed precise versions of base image

Until now, we tend to use ``latest`` or ``x.y`` (major version) as image tag when specifying base image for our Dockerfile.
The problem is that those container image can be updated whenever a minor version is released causing our cached image to be invalidated and trigger their pull and rebuild of our custom images.
Additionally, we don't have certainty on which version this loose tags base images are at, as the upgrade is not audited on our side.

Instead, we use precise tag for the base image (x.y.z) so to remove any chance for the base image to change.
We will manage upgrade of our infrastructure ourselves with our own auditing.

## Comment out docker pull and build instructions related to FUW

the container services associate with File Upload Wizard are not deployed on production environment, so there's no need
to pull and build their images.

## Fix tag for custom images

The production images built in the build job are tagged with the environment they are for.
Unfortunately, when they were pulled before the build the wrong tag  (``latest`` instead of ``stagging`` or ``live``) was used, causing the ``docker build`` to think there is no image so it build  entirely new production images again.
An associatated bug was the absence of the environment specific tag in ``docker-compose-build.yml`` where we define what image to use as cache.

## Move transcient docker instructions at the end of the Dockefile

In the ``Production-Web-Dockerfile``,  the block ``RUN apk ...`` was triggered every time causing extra compile time becuase previous layer is constantly invalidated by definition (the block creating site config which never persist). 
By moving the ``RUN apk ...`` before the Site config block we enable the compilation stage to be cached.

# Tests in CI

For the last few weeks we've made a lot of change to the infrastructure without running the test suites in CI, when I reactivated the test job, it failed mostly because of those changes, so the test job had to be adapted. The main change is that we now use the ``up.sh`` project setup script on CI test job as well.
I've also added an <exclude> block to functional tests in ``protected/tests/phpunit.xml`` to exclude flaky tests and those related to File Upload Wizard.

The other change is that Composer installed binaries like ``phpunit``, ``beat``,  ``phpcov`` need to be fully referenced because on CI we don't have the ``bin/`` symlink in project directory.

Finally the main gigadb test suite CI job is now re-instated.

# Bug fix

Fix the ``pg_dump`` command in ``convert_production_db_to_latest_ver.sh`` to use the version used by @pli888

TODO:

* [x] looking at build logs, I see that a lot of times is spent building the php base image, these changes will this happen only once per job, as the container is then available locally when building all our container image
* [x] by logging with Docker Hub account credentials, the process is no longer anonymous and it's highly possible that Docker shapes the bandwidth to their servers differently wether we are anonymous or logged in (not least because they have set up rate limits for docker pulls)
* [x] Our pipelines already use artifacts to pass data between job, we will pass docker base images the same way
* [x] The credentials for Docker Hub account (username and access token) need to be stored in GitLab varfiables set for the "All (default)" environment option
* [x] Fix root certificate issue that stems from [Let's Encrypt root certificate expiration](https://community.letsencrypt.org/t/help-thread-for-dst-root-ca-x3-expiration-september-2021/149190/51)