### PR TITLE
Add uptime status page to gigadb website

### DIFF
--- a/docs/UPTIME_STATUS_PAGE.md
+++ b/docs/UPTIME_STATUS_PAGE.md
@@ -1,0 +1,22 @@
+# GigaDB server monitoring tool: UptimeRobot
+
+UptimeRobot provides uptime monitoring service, its free tier plan allows up to 50 monitors with minimum monitoring interval `5mins` and 1 status page.
+Currently, the GigaDB monitoring page is at [here](https://stats.uptimerobot.com/LGVQXSkN1y).
+
+### How GigaDB servers are monitored
+
+| Server name | Type of Check | value to check | 
+| --- | --- | --- |
+| GigaDB FTP server | HTTP(S) | https://ftp.cngb.org/pub/gigadb/pub/10.5524/ |
+| GigaDB Web Site (LIVE) | HTTP(S) | https://gigadb.org |
+| GigaDB Database Server (LIVE) | Port | database-live.gigadb.org:5432 |
+| GigaDB Web Site (STAGING) | HTTP(S) | https://staging.gigadb.org |
+| GigaDB Database Server (STAGING) | Port | database-staging.gigadb.org:5432 |
+| GigaDB CI/CD Pipeline | HTTP(S) | https://gitlab.com/gigascience |
+| GigaDB Codebase repository | HTTP(S) | https://github.com/gigascience/ |
+
+### Where to find the login credentials for UptimeRobot dashboard?
+The `uptime_robot_login_account` and `uptime_robot_login_password` are stored in [gitlab variable](https://gitlab.com/gigascience/cnhk-infra/-/settings/ci_cd) under gigascience repo.
+
+### How to add monitor and create a status page?
+Please refer to this [official doc](https://uptimerobot.com/faq/), which is up-to-date and easy to follow.

--- a/features/uptime-status-page.feature
+++ b/features/uptime-status-page.feature
@@ -1,0 +1,56 @@
+@issue-739
+Feature:
+  As a gigadb user
+  I want to know the the server status of gigadb
+  So that the server's status could be monitored
+
+  Background:
+    Given Gigadb web site is loaded with production-like data
+
+  @ok
+  Scenario: Systems Status could be found in the main page
+    Given I am not logged in to Gigadb web site
+    When I go to "/index.php"
+    And I click on the "Help" button
+    Then I should see "Systems Status"
+
+  @ok
+  Scenario: Go to uptime status dashboard from the main page
+    Given I am not logged in to Gigadb web site
+    And I go to "/index.php"
+    And I click on the "Help" button
+    And I click on the "Systems Status" button
+    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
+    And I should see "gigadb server monitoring test"
+
+  @ok
+  Scenario: Systems Status could be found in the faq page
+    Given I am not logged in to Gigadb web site
+    When I go to "/site/faq"
+    And I click on the "Help" button
+    Then I should see "Systems Status"
+
+  @ok
+  Scenario: Go to uptime status dashboard from the faq page
+    Given I am not logged in to Gigadb web site
+    And I go to "/site/faq"
+    And I click on the "Help" button
+    And I click on the "Systems Status" button
+    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
+    And I should see "gigadb server monitoring test"
+
+  @ok
+  Scenario: Systems Status could be found in the dataset page
+    Given I am not logged in to Gigadb web site
+    When I go to "/dataset/100016"
+    And I click on the "Help" button
+    Then I should see "Systems Status"
+
+  @ok
+  Scenario: Go to uptime status dashboard from the dataset page
+    Given I am not logged in to Gigadb web site
+    And I go to "/dataset/100016"
+    And I click on the "Help" button
+    And I click on the "Systems Status" button
+    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
+    And I should see "gigadb server monitoring test"

--- a/features/uptime-status-page.feature
+++ b/features/uptime-status-page.feature
@@ -20,8 +20,8 @@ Feature:
     And I go to "/index.php"
     And I click on the "Help" button
     And I click on the "Systems Status" button
-    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
-    And I should see "gigadb server monitoring test"
+    Then I am on "https://stats.uptimerobot.com/LGVQXSkN1y"
+    And I should see "GigaDB"
 
   @ok
   Scenario: Systems Status could be found in the faq page
@@ -36,8 +36,8 @@ Feature:
     And I go to "/site/faq"
     And I click on the "Help" button
     And I click on the "Systems Status" button
-    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
-    And I should see "gigadb server monitoring test"
+    Then I am on "https://stats.uptimerobot.com/LGVQXSkN1y"
+    And I should see "GigaDB"
 
   @ok
   Scenario: Systems Status could be found in the dataset page
@@ -52,5 +52,5 @@ Feature:
     And I go to "/dataset/100016"
     And I click on the "Help" button
     And I click on the "Systems Status" button
-    Then I am on "https://stats.uptimerobot.com/mknA9up1BP"
-    And I should see "gigadb server monitoring test"
+    Then I am on "https://stats.uptimerobot.com/LGVQXSkN1y"
+    And I should see "GigaDB"

--- a/features/uptime-status-page.feature
+++ b/features/uptime-status-page.feature
@@ -1,7 +1,7 @@
 @issue-739
 Feature:
   As a gigadb user
-  I want to know the the server status of gigadb
+  I want to know the the server's status of gigadb
   So that the server's status could be monitored
 
   Background:

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -152,6 +152,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
+                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>

--- a/protected/views/layouts/new_datasetpage.php
+++ b/protected/views/layouts/new_datasetpage.php
@@ -152,7 +152,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
-                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
+                                <li><a href="https://stats.uptimerobot.com/LGVQXSkN1y">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -138,6 +138,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
+                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>

--- a/protected/views/layouts/new_faq.php
+++ b/protected/views/layouts/new_faq.php
@@ -138,7 +138,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
-                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
+                                <li><a href="https://stats.uptimerobot.com/LGVQXSkN1y">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -138,6 +138,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
+                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>

--- a/protected/views/layouts/new_main.php
+++ b/protected/views/layouts/new_main.php
@@ -138,7 +138,7 @@
                                 <li><a href="/site/help">Help</a></li>
                                 <li><a href="/site/faq">FAQ</a></li>
                                 <li><a href="/site/guide">Guidelines</a></li>
-                                <li><a href="https://stats.uptimerobot.com/mknA9up1BP">Systems Status</a></li>
+                                <li><a href="https://stats.uptimerobot.com/LGVQXSkN1y">Systems Status</a></li>
                             </ul>
                         </li>
                         <li><a href="/site/term">Terms of use</a></li>


### PR DESCRIPTION
This PR is for [Monitor uptime status of new infrastructure #739](https://github.com/gigascience/gigadb-website/issues/739)

### Changes to the view class
1. Created a new row `Systems Status` when `Help` button is clicked
![image](https://user-images.githubusercontent.com/64770635/138849794-beae69b6-76aa-485a-a3ee-4f9b5a2b1fe2.png)
2. When `Systems Status` is clicked, the page will redirected to UptimeRobot [status page](https://stats.uptimerobot.com/mknA9up1BP)
![image](https://user-images.githubusercontent.com/64770635/139610681-81121932-ba68-4064-882e-7b6abc6796ca.png)

### Acceptance test
1. The `Systems Status` link is working from the gigadb website main page, faq page and dataset page.
