### PR TITLE
Fix SAST job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ include:
   - local: "ops/pipelines/gigadb-deploy-jobs.yml"
   - local: "ops/pipelines/gigadb-operations-jobs.yml"
 #  - local: "gigadb/app/tools/files-url-updater/gitlab-config.yml"
+  - template: Security/SAST.gitlab-ci.yml
 
 services:
   - docker:19.03.12-dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,8 +80,8 @@ cache:
 
 before_script:
   - env | grep "^CI_" > $APPLICATION/.ci_env
-  - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env
-  - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
+  - env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env
+  - env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
   - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash'
   # Pin docker-compose version to stop installation error
   - '[[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,13 +54,13 @@ variables:
 
 
 include:
+  - template: Security/SAST.gitlab-ci.yml
   - local: "ops/pipelines/gigadb-build-jobs.yml"
   - local: "ops/pipelines/gigadb-test-jobs.yml"
   - local: "ops/pipelines/gigadb-conformance-security-jobs.yml"
   - local: "ops/pipelines/gigadb-deploy-jobs.yml"
   - local: "ops/pipelines/gigadb-operations-jobs.yml"
 #  - local: "gigadb/app/tools/files-url-updater/gitlab-config.yml"
-  - template: Security/SAST.gitlab-ci.yml
 
 services:
   - docker:19.03.12-dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,9 +79,9 @@ cache:
       - gigadb/app/client/web/node_modules
 
 before_script:
-  - env | grep "^CI_" > $APPLICATION/.ci_env
-  - env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env
-  - env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
+  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
   - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash'
   # Pin docker-compose version to stop installation error
   - '[[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,9 @@ before_script:
   - env | grep "^CI_" > $APPLICATION/.ci_env
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
-  - [[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash
+  - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash'
   # Pin docker-compose version to stop installation error
-  - [[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0
+  - '[[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0'
 
 sd_gigadb:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,9 @@ before_script:
   - env | grep "^CI_" > $APPLICATION/.ci_env
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env
   - env | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets
-  - apk add --no-cache py-pip bash
+  - [[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash
   # Pin docker-compose version to stop installation error
-  - pip install docker-compose~=1.23.0
+  - [[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0
 
 sd_gigadb:
   variables:

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-b_gigadb:
+.b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -125,11 +125,11 @@ b_gigadb:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending remote variables at the end of the .env and .secrets
     - env > full_env.txt
-    - env | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" >> $APPLICATION/.env
-    - env | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
-    - env | grep -iE "gitlab_private_token">> $APPLICATION/.secrets
-    - env | grep -iE "CI_PROJECT_URL">> $APPLICATION/.secrets
-    - env | grep -iE "^(gigadb_|fuw_).+=.+$" | tee -a $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "gitlab_private_token">> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "CI_PROJECT_URL">> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "^(gigadb_|fuw_).+=.+$" | tee -a $APPLICATION/.secrets
     # pulling the CI build of the application from registry and configure it for staging for the purpose of building production containers
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
 #    - docker pull registry.gitlab.com/$CI_PROJECT_PATH/fuw-admin:latest || true

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-.b_gigadb:
+b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -69,3 +69,24 @@ check_PHPDoc:
     - docker-compose run --rm test ./tests/coverage_check
 
 
+bandit-sast:
+  stage: conformance and security
+  when: manual
+
+eslint-sast:
+  stage: conformance and security
+  when: manual
+
+nodejs-scan-sast:
+  stage: conformance and security
+
+phpcs-security-audit-sast:
+  stage: conformance and security
+
+semgrep-sast:
+  stage: conformance and security
+  when: manual
+
+spotbugs-sast:
+  stage: conformance and security
+  when: manual

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -71,18 +71,28 @@ check_PHPDoc:
 
 bandit-sast:
   stage: conformance and security
+  variables:
+    SAST_DISABLED: "true"
 
 eslint-sast:
   stage: conformance and security
+  variables:
+    SAST_DISABLED: "true"
 
 nodejs-scan-sast:
   stage: conformance and security
+  variables:
+    SAST_DISABLED: "true"
 
 phpcs-security-audit-sast:
   stage: conformance and security
 
 semgrep-sast:
   stage: conformance and security
+  variables:
+    SAST_DISABLED: "true"
 
 spotbugs-sast:
   stage: conformance and security
+  variables:
+    SAST_DISABLED: "true"

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -1,39 +1,3 @@
-check_SAST:
-  stage: conformance and security
-  script:
-    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
-    - docker run
-      --env SAST_CONFIDENCE_LEVEL="${SAST_CONFIDENCE_LEVEL:-3}"
-      --volume "$PWD:/code"
-      --volume /var/run/docker.sock:/var/run/docker.sock
-      "registry.gitlab.com/gitlab-org/security-products/sast:$SP_VERSION" /app/bin/run /code
-  artifacts:
-    paths: [gl-sast-report.json]
-  allow_failure: true
-  when: manual
-
-# job (manual, with failure allowed) for running Dymamic Application Security Testing
-# See: https://docs.gitlab.com/ee/ci/examples/dast.html
-check_DAST:
-  stage: conformance and security
-  image: registry.gitlab.com/gitlab-org/security-products/zaproxy
-  variables:
-    website: "https://gigadb-staging.pommetab.com/"
-  before_script:
-    - echo "About to run DAST"
-  script:
-    - mkdir /zap/wrk/
-    - /zap/zap-baseline.py -J gl-dast-report.json -t $website || true
-    - cp /zap/wrk/gl-dast-report.json .
-  after_script:
-    - echo "Finished running DAST"
-  artifacts:
-    reports:
-      dast: gl-dast-report.json
-  allow_failure: true
-  when: manual
-
-
 check_PSR2:
   stage: conformance and security
   artifacts:

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -71,11 +71,9 @@ check_PHPDoc:
 
 bandit-sast:
   stage: conformance and security
-  when: manual
 
 eslint-sast:
   stage: conformance and security
-  when: manual
 
 nodejs-scan-sast:
   stage: conformance and security
@@ -85,8 +83,6 @@ phpcs-security-audit-sast:
 
 semgrep-sast:
   stage: conformance and security
-  when: manual
 
 spotbugs-sast:
   stage: conformance and security
-  when: manual

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -18,11 +18,11 @@
     # login to gitlab container registry
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
     # appending production variables at the end of the .env and .secrets
-    - env | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" >> $APPLICATION/.env
-    - env | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
-    - env | grep "^CI_API_V4_URL" >> $APPLICATION/.env
-    - env | grep "^CI_PROJECT_PATH" >> $APPLICATION/.env
-    - env | grep "^GITLAB_PRIVATE_TOKEN" >> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep "^CI_API_V4_URL" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep "^CI_PROJECT_PATH" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep "^GITLAB_PRIVATE_TOKEN" >> $APPLICATION/.secrets
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker

--- a/ops/pipelines/gigadb-operations-jobs.yml
+++ b/ops/pipelines/gigadb-operations-jobs.yml
@@ -9,8 +9,8 @@
   stage: operations
   script: &configure-docker-compose
     # appending staging variables at the end of the .env and .secrets
-    - env | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" >> $APPLICATION/.env
-    - env | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tlsauth)" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
     # Steps below are for interacting with the remote staging server to deploy, configure and start the production containers using staging compose file
     # Create client certificate files for authenticating with remote docker daemon
     - mkdir -pv ~/.docker


### PR DESCRIPTION
# Fix SAST job

Implements task gigascience/gigadb-website#823.

The SAST job was broken because GitLab has updated the way SAST analysers are run so they all share common approach and API.

The entry point to the documentation is this section:

https://docs.gitlab.com/ee/user/application_security/sast/index.html#configure-sast-manually

I had to apply some of the instructions from this section: 

https://docs.gitlab.com/ee/user/application_security/sast/index.html#overriding-sast-jobs

In order to fit the SAST process with our workflow (our stages and main language):

* we put security jobs in the "Conformance and Security" stage (by default SAST analysers want to be in the "test" stage)
* we want to focus on just the PHP codebase for now so we can learn to use SAST on one aspect, we will extend to the other language in use later, so the other analysers are disabled for now


The inclusion of the GitLab SAST template is done in ``.gitlab-ci.yml``, but it needs to be done before the inclusion of ``gigadb-conformance-security-jobs.yml``,
because the latter will have the definition of the  overriden SAST jobs.


The SAST report can be viewed in the Security tab of each pipeline  landing page after the analysers has finished running:
e.g: https://gitlab.com/gigascience/forks/rija-gigadb-website/-/pipelines/395887431



