### PR TITLE
Enable RDS instance to be restored from database snapshots and backups

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ variables:
   PHP_VERSION: "7.1"
   YII_VERSION: "1.1.20"
   YII2_VERSION: "2.0.15.1"
-  POSTGRES_VERSION: "9.6"
+  POSTGRES_VERSION: "11.13"
   HOME_URL: "gigadb.gigasciencejournal.com"
   FILES_PUBLIC_URL: "http://gigadb.gigasciencejournal.com:9170"
   PUBLIC_HTTP_PORT: "9170"

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -654,10 +654,17 @@ thus reducing the risk of hitting weekly rate-limit for certificate creation imp
 Those directories start empty, but the ``tf_init.sh`` and ``ansible_init.sh`` scripts below will populate them with necessary files
 so we can run ``terraform`` and ``ansible-playbook`` commands from those directories for a safe provisioning of the desired environment.
 
-#### 2. Initialise Terraform
+#### 2. Initialise and provision with Terraform
 
 ```
 $ ../../../scripts/tf_init.sh --project gigascience/forks/rija-gigadb-website --env environment
+You need to specify the path to the ssh private key to use to connect to the EC2 instance: ~/.ssh/id-rsa-aws.pem
+You need to specify your GitLab username: pli888
+You need to specify a backup file created by the files-url-updater tool: ../../../../gigadb/app/tools/files-url-updater/sql/gigadbv3_20210929_v9.3.25.backup
+# Now provision with Terraform
+$ terraform plan  
+$ terraform apply
+$ terraform refresh
 ```
 
 where you replace ``gigascience/forks/rija-gigadb-website`` with the appropriate GitLab project.
@@ -671,16 +678,11 @@ $ ../../../scripts/ansible_init.sh --env environment
 
 where you replace ``environment`` with ``staging`` or ``live``
 
-#### 4. Provision with  Terraform and perform Ansible playbook
+#### 4. Perform Ansible playbook
 
 Ensure you are still in ``ops/infractructure/envs/staging`` or ``ops/infractructure/envs/live``
 
 ```
-$ pwd
-$ terraform plan
-$ terraform apply
-$ terraform refresh
-$ ../../../scripts/ansible_init.sh --env environment
 $ ansible-playbook -i ../../inventories dockerhost_playbook.yml
 $ ansible-playbook -i ../../inventories bastion_playbook.yml
 ```

--- a/docs/SETUP_CI_CD_PIPELINE.md
+++ b/docs/SETUP_CI_CD_PIPELINE.md
@@ -707,6 +707,42 @@ We can proceed with deployment to the target environment by triggering manual jo
 
 The application should be available at the url defined in $REMOTE_HOME_URL for a given environment.
 
+### Restoration of database snapshots
+```
+# Go to environment directory
+$ cd <path>/gigadb-website/ops/infrastructure/envs/staging
+
+# Terminate existing RDS service
+$ terraform destroy --target module.rds
+
+# Restore database snapshot
+$ terraform plan -var snapshot_identifier="snapshot-for-testing"
+$ terraform apply -var snapshot_identifier="snapshot-for-testing"
+$ terraform refresh
+```
+
+### Restoration of database backups
+```
+# Go to environment directory
+$ cd <path>/gigadb-website/ops/infrastructure/envs/staging
+
+# Terminate existing RDS service
+$ terraform destroy --target module.rds
+
+# Copy override.tf to staging environment
+$ ../../../scripts/tf_init.sh --project gigascience/forks/pli888-gigadb-website --env staging --restore-backup
+
+# Backups can either be restored to its latest restorable time or to a specific
+# time.
+
+# To restore to latest restorable time - need to override database name as this 
+# will come from the backup
+$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var use_latest_restorable_time="true"
+
+# To restore to specific time in backup - need to override database name as this 
+# will come from the backup
+$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var utc_restore_time="2021-10-27T06:02:12+00:00"
+```
 
 ### Troubleshooting
 

--- a/docs/awsdocs/policy-ec2.md
+++ b/docs/awsdocs/policy-ec2.md
@@ -71,7 +71,7 @@ when using the AWS management console.
         },
         {
             "Sid": "RunInstancesWithOwnerTagRestriction",
-            "Effect": "Deny",
+            "Effect": "Allow",
             "Action": [
                 "ec2:CreateVolume",
                 "ec2:RunInstances"
@@ -81,8 +81,8 @@ when using the AWS management console.
                 "arn:aws:ec2:*:*:instance/*"
             ],
             "Condition": {
-                "StringNotLike": {
-                    "aws:RequestTag/Owner": "${aws.username}"
+                "StringEqualsIgnoreCase": {
+                    "aws:ResourceTag/Owner": "${aws:username}"
                 }
             }
         },
@@ -124,7 +124,7 @@ when using the AWS management console.
             ],
             "Resource": "*",
             "Condition": {
-                "StringEquals": {
+                "StringEqualsIgnoreCase": {
                     "ec2:ResourceTag/Owner": "${aws:username}"
                 }
             }

--- a/docs/awsdocs/policy-rds.md
+++ b/docs/awsdocs/policy-rds.md
@@ -17,7 +17,10 @@ Policy Name: GigadbRDSAccess
         {
             "Sid": "AllowEC2Describe",
             "Effect": "Allow",
-            "Action": "ec2:Describe*",
+            "Action": [
+                "ec2:Describe*",
+                "ec2:DescribeSubnets"
+            ],
             "Resource": "*"
         },
         {
@@ -29,6 +32,32 @@ Policy Name: GigadbRDSAccess
                 "iam:ListInstanceProfilesForRole"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "WorkWithElasticIPAddresses",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAddresses",
+                "ec2:AllocateAddress",
+                "ec2:DescribeInstances",
+                "ec2:AssociateAddress",
+                "ec2:DescribeNetworkInterfaces"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ModifyElasticIPAddresses",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DisassociateAddress",
+                "ec2:ReleaseAddress"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEqualsIgnoreCase": {
+                    "ec2:ResourceTag/Owner": "${aws:username}"
+                }
+            }
         },
         {
             "Sid": "CreateRDSInstance",
@@ -53,7 +82,8 @@ Policy Name: GigadbRDSAccess
                 "ec2:AssociateSubnetCidrBlock",
                 "rds:CreateDBSubnetGroup",
                 "rds:AddTagsToResource",
-                "ec2:GetManagedPrefixListAssociations"
+                "ec2:GetManagedPrefixListAssociations",
+                "ec2:CreateNatGateway"
             ],
             "Resource": "*"
         },
@@ -76,10 +106,19 @@ Policy Name: GigadbRDSAccess
             "Action": "rds:CreateDBInstance",
             "Resource": "*",
             "Condition": {
-                "StringEquals": {
-                    "aws:RequestTag/Owner": "${aws.username}"
+                "StringEqualsIgnoreCase": {
+                    "aws:RequestTag/Owner": "${aws:username}"
                 }
             }
+        },
+        {
+            "Sid": "RestoreDBInstanceToPointInTime",
+            "Effect": "Allow",
+            "Action": [
+                "rds:RestoreDBInstanceToPointInTime",
+                "rds:DeleteDBInstanceAutomatedBackup"
+            ],
+            "Resource": "*"
         },
         {
             "Sid": "DeleteEC2ResourcesWithOwnerTagRestriction",
@@ -100,11 +139,12 @@ Policy Name: GigadbRDSAccess
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:DeleteVpc",
                 "ec2:DeleteRoute",
-                "ec2:DisassociateRouteTable"
+                "ec2:DisassociateRouteTable",
+                "ec2:DeleteNatGateway"
             ],
             "Resource": "*",
             "Condition": {
-                "StringEquals": {
+                "StringEqualsIgnoreCase": {
                     "ec2:ResourceTag/Owner": "${aws:username}"
                 }
             }
@@ -129,7 +169,8 @@ Policy Name: GigadbRDSAccess
             "Action": [
                 "rds:DeleteDBInstance",
                 "rds:RebootDBInstance",
-                "rds:ModifyDBInstance"
+                "rds:ModifyDBInstance",
+                "rds:CreateDBSnapshot"
             ],
             "Effect": "Allow",
             "Resource": "*",

--- a/ops/configuration/variables/env-sample
+++ b/ops/configuration/variables/env-sample
@@ -49,7 +49,7 @@ YII_DEBUG=true
 ### Core services managed in Docker compose ##############################################################################
 NGINX_VERSION=1.15
 PHP_VERSION=7.1
-POSTGRES_VERSION=9.6
+POSTGRES_VERSION=11.13
 YII_VERSION=1.1.20
 YII2_VERSION=2.0.15.1
 

--- a/ops/infrastructure/modules/rds-instance/README.md
+++ b/ops/infrastructure/modules/rds-instance/README.md
@@ -15,7 +15,9 @@
 $ cd <path to>/gigadb-website/ops/infrastructure/envs/staging
 # Copy terraform files to staging environment
 $ ../../../scripts/tf_init.sh --project gigascience/forks/pli888-gigadb-website --env staging
-
+You need to specify the path to the ssh private key to use to connect to the EC2 instance: ~/.ssh/id-rsa-aws.pem
+You need to specify your GitLab username: pli888
+You need to specify a backup file created by the files-url-updater tool: ../../../../gigadb/app/tools/files-url-updater/sql/gigadbv3_20210929_v9.3.25.backup
 # Provision with Terraform
 $ terraform plan  
 $ terraform apply

--- a/ops/infrastructure/modules/rds-instance/input.tf
+++ b/ops/infrastructure/modules/rds-instance/input.tf
@@ -5,3 +5,4 @@ variable "gigadb_db_user" {}
 variable "gigadb_db_password" {}
 variable "vpc_id" {}
 variable "rds_subnet_ids" {}
+variable "snapshot_identifier" {}

--- a/ops/infrastructure/modules/rds-instance/input.tf
+++ b/ops/infrastructure/modules/rds-instance/input.tf
@@ -6,3 +6,4 @@ variable "gigadb_db_password" {}
 variable "vpc_id" {}
 variable "rds_subnet_ids" {}
 variable "snapshot_identifier" {}
+variable "restore_to_point_in_time" {}

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -39,9 +39,9 @@ module "db" {
   create_db_option_group    = false
   create_db_parameter_group = false
   engine                    = "postgres"
-  engine_version            = "9.6"
-  family                    = "postgres9"  # DB parameter group
-  major_engine_version      = "9"          # DB option group
+  engine_version            = "11.13"
+  family                    = "postgres11"  # DB parameter group
+  major_engine_version      = "11"          # DB option group
   instance_class            = "db.t3.micro"
   allocated_storage         = 8
   deletion_protection       = false

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -1,3 +1,7 @@
+locals {
+  tstamp = formatdate("YYYYMMDDhhmmss", timestamp())
+}
+
 module "security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 4"
@@ -19,20 +23,7 @@ module "security_group" {
 
 module "db" {
   source = "terraform-aws-modules/rds/aws"
-
-  # Only lowercase alphanumeric characters and hyphens allowed in "identifier"
   identifier = "rds-server-${var.deployment_target}-${var.owner}"
-
-  create_db_option_group    = false
-  create_db_parameter_group = false
-
-  engine               = "postgres"
-  engine_version       = "9.6"
-  family               = "postgres9" # DB parameter group
-  major_engine_version = "9"         # DB option group
-  instance_class       = "db.t3.micro"
-
-  allocated_storage = 20
 
   name                   = var.gigadb_db_database
   username               = var.gigadb_db_user
@@ -42,16 +33,23 @@ module "db" {
   subnet_ids             = var.rds_subnet_ids
   vpc_security_group_ids = [module.security_group.security_group_id]
 
-  maintenance_window = "Mon:00:00-Mon:03:00"
-  backup_window      = "03:00-06:00"
-
-  backup_retention_period = 0
-  skip_final_snapshot     = true
-  deletion_protection     = false
-
-  tags = {
-//    Name = "rds_server_${var.deployment_target}"
-  }
+  create_db_option_group    = false
+  create_db_parameter_group = false
+  engine                    = "postgres"
+  engine_version            = "9.6"
+  family                    = "postgres9"  # DB parameter group
+  major_engine_version      = "9"          # DB option group
+  instance_class            = "db.t3.micro"
+  allocated_storage         = 8
+  deletion_protection       = false
+  maintenance_window        = "Mon:00:00-Mon:03:00"
+  backup_window             = "03:00-06:00"  # UTC time
+  backup_retention_period   = 5
+  skip_final_snapshot       = false  # Create final snapshot
+  final_snapshot_identifier = "snapshot-final-${var.deployment_target}-${var.owner}-${local.tstamp}"
+  copy_tags_to_snapshot     = true
+  delete_automated_backups  = false  # Do not delete backups on RDS instance termination
+  apply_immediately         = true
 }
 
 output "rds_instance_address" {

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -26,6 +26,7 @@ module "db" {
   identifier = "rds-server-${var.deployment_target}-${var.owner}"
 
   snapshot_identifier = var.snapshot_identifier
+  restore_to_point_in_time = var.restore_to_point_in_time
 
   name                   = var.gigadb_db_database
   username               = var.gigadb_db_user

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -25,6 +25,8 @@ module "db" {
   source = "terraform-aws-modules/rds/aws"
   identifier = "rds-server-${var.deployment_target}-${var.owner}"
 
+  snapshot_identifier = var.snapshot_identifier
+
   name                   = var.gigadb_db_database
   username               = var.gigadb_db_user
   password               = var.gigadb_db_password

--- a/ops/infrastructure/modules/rds-instance/rds-instance.tf
+++ b/ops/infrastructure/modules/rds-instance/rds-instance.tf
@@ -47,7 +47,7 @@ module "db" {
   deletion_protection       = false
   maintenance_window        = "Mon:00:00-Mon:03:00"
   backup_window             = "03:00-06:00"  # UTC time
-  backup_retention_period   = 5
+  backup_retention_period   = 5  # days
   skip_final_snapshot       = false  # Create final snapshot
   final_snapshot_identifier = "snapshot-final-${var.deployment_target}-${var.owner}-${local.tstamp}"
   copy_tags_to_snapshot     = true

--- a/ops/infrastructure/override.tf
+++ b/ops/infrastructure/override.tf
@@ -1,0 +1,21 @@
+variable "source_dbi_resource_id" {
+  type = string
+}
+
+variable "utc_restore_time" {
+  type = string
+  default = null
+}
+
+variable "use_latest_restorable_time" {
+  type = bool
+  default = null
+}
+
+module "rds" {
+  restore_to_point_in_time = {
+    source_dbi_resource_id     = var.source_dbi_resource_id
+    restore_time = var.utc_restore_time
+    use_latest_restorable_time = var.use_latest_restorable_time
+  }
+}

--- a/ops/infrastructure/override.tf
+++ b/ops/infrastructure/override.tf
@@ -14,7 +14,7 @@ variable "use_latest_restorable_time" {
 
 module "rds" {
   restore_to_point_in_time = {
-    source_dbi_resource_id     = var.source_dbi_resource_id
+    source_dbi_resource_id = var.source_dbi_resource_id
     restore_time = var.utc_restore_time
     use_latest_restorable_time = var.use_latest_restorable_time
   }

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -44,6 +44,12 @@ variable "snapshot_identifier" {
   default = null
 }
 
+variable "restore_to_point_in_time" {
+  type = string
+  description = "A map to restoring RDS service from an automated backup"
+  default = null
+}
+
 data "external" "callerUserName" {
   program = ["${path.module}/getIAMUserNameToJSON.sh"]
 }
@@ -185,6 +191,9 @@ module "rds" {
   # This variable needs to be overridden on cmd line in order to create an RDS
   # service by restoring from a snapshot
   snapshot_identifier = var.snapshot_identifier
+
+  # For restoring RDS from automated backup
+  restore_to_point_in_time = var.restore_to_point_in_time
 
   vpc_id = module.vpc.vpc_id
   rds_subnet_ids = module.vpc.database_subnets

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # DEPLOY A GIGADB APPLICATION IN AWS
-# This terraform script sets up a complete GigaDB application in AWS. A VPC is
-# created in AWS cloud into which an EC2 instance hosting a Docker Host and a
+# This terraform script sets up a complete GigaDB application in AWS. A VPC is 
+# created in AWS cloud into which an EC2 instance hosting a Docker Host and a 
 # RDS instance hosting the PostgreSQL database are launched into.
 # ------------------------------------------------------------------------------
 
@@ -94,29 +94,29 @@ module "vpc" {
   version = "~> 2"
 
   name = "vpc-ape1-${var.deployment_target}-gigadb"
-  # CIDR block is a range of IPv4 addresses in the VPC. This cidr block below
-  # means that the main route table has the following routes: Destination =
+  # CIDR block is a range of IPv4 addresses in the VPC. This cidr block below 
+  # means that the main route table has the following routes: Destination = 
   # 10.99.0.0/18 , Target = local
   cidr = "10.99.0.0/18"
-
+  
   # VPC spans all the availability zones in region
   azs = data.aws_availability_zones.available.names
 
   # We can add one or more subnets into each AZ. A subnet is required to launch
-  # AWS resources into a VPC and is a range of IP addresses. Each subnet has a
+  # AWS resources into a VPC and is a range of IP addresses. Each subnet has a 
   # CIDR block which is a subset of the VPC CIDR block.
 
   # Public subnets will contain resources with public IP addresses and routes
-  # A internet gateway is automatically created for these public subnets. An
-  # internet gateway exposes resources with public IPs to inbound traffic
-  # from the internet. All public subnets route to an Internet Gateway for
+  # A internet gateway is automatically created for these public subnets. An 
+  # internet gateway exposes resources with public IPs to inbound traffic 
+  # from the internet. All public subnets route to an Internet Gateway for 
   # non-local addresses which is what makes the subnet public.
   public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
   public_subnet_tags = {
     Name = "subnet-public"
   }
 
-  # Private subnets contain resources that do not have public IPs. They have
+  # Private subnets contain resources that do not have public IPs. They have 
   # private IPs and can only interact with resources inside the same network
   # Resources in a private subnet needing internet access require a NAT device
   # private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
@@ -130,7 +130,7 @@ module "vpc" {
   }
 
   # You can enable communication from internet to RDS is via an internet gateway
-  # to provide public access to RDS instance, but is not recommended for
+  # to provide public access to RDS instance, but is not recommended for 
   # production! These parameters are all false so no public access to RDS
   create_database_subnet_group = false
   create_database_subnet_route_table = false
@@ -142,8 +142,8 @@ module "vpc" {
 
   # NAT gateways provide resources in private subnets that do not have
   # public IP address with outbound access to the public Internet or other AWS
-  # resources. NAT gateways are placed in public subnet. Does RDS instance need
-  # a NAT as it will be placed in private subnet? Access to it will be via a
+  # resources. NAT gateways are placed in public subnet. Does RDS instance need 
+  # a NAT as it will be placed in private subnet? Access to it will be via a 
   # bastion server.
   # enable_nat_gateway = false
   # single_nat_gateway = false
@@ -161,7 +161,7 @@ module "ec2_dockerhost" {
   key_name = var.key_name
   eip_tag_name = "eip-gigadb-${var.deployment_target}-${data.external.callerUserName.result.userName}"
   vpc_id = module.vpc.vpc_id
-  # Locate Dockerhost EC2 instance in public subnet so users can access website
+  # Locate Dockerhost EC2 instance in public subnet so users can access website 
   # container app
   public_subnet_id = module.vpc.public_subnets[0]
 }

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # DEPLOY A GIGADB APPLICATION IN AWS
-# This terraform script sets up a complete GigaDB application in AWS. A VPC is 
-# created in AWS cloud into which an EC2 instance hosting a Docker Host and a 
+# This terraform script sets up a complete GigaDB application in AWS. A VPC is
+# created in AWS cloud into which an EC2 instance hosting a Docker Host and a
 # RDS instance hosting the PostgreSQL database are launched into.
 # ------------------------------------------------------------------------------
 
@@ -45,8 +45,23 @@ variable "snapshot_identifier" {
 }
 
 variable "restore_to_point_in_time" {
-  type = string
+  type = map
   description = "A map to restoring RDS service from an automated backup"
+  default = null
+}
+
+variable "source_dbi_resource_id" {
+  type = string
+  default = null
+}
+
+variable "use_latest_restorable_time" {
+  type = bool
+  default = null
+}
+
+variable "utc_restore_time" {
+  type = string
   default = null
 }
 
@@ -79,29 +94,29 @@ module "vpc" {
   version = "~> 2"
 
   name = "vpc-ape1-${var.deployment_target}-gigadb"
-  # CIDR block is a range of IPv4 addresses in the VPC. This cidr block below 
-  # means that the main route table has the following routes: Destination = 
+  # CIDR block is a range of IPv4 addresses in the VPC. This cidr block below
+  # means that the main route table has the following routes: Destination =
   # 10.99.0.0/18 , Target = local
   cidr = "10.99.0.0/18"
-  
+
   # VPC spans all the availability zones in region
   azs = data.aws_availability_zones.available.names
 
   # We can add one or more subnets into each AZ. A subnet is required to launch
-  # AWS resources into a VPC and is a range of IP addresses. Each subnet has a 
+  # AWS resources into a VPC and is a range of IP addresses. Each subnet has a
   # CIDR block which is a subset of the VPC CIDR block.
 
   # Public subnets will contain resources with public IP addresses and routes
-  # A internet gateway is automatically created for these public subnets. An 
-  # internet gateway exposes resources with public IPs to inbound traffic 
-  # from the internet. All public subnets route to an Internet Gateway for 
+  # A internet gateway is automatically created for these public subnets. An
+  # internet gateway exposes resources with public IPs to inbound traffic
+  # from the internet. All public subnets route to an Internet Gateway for
   # non-local addresses which is what makes the subnet public.
   public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
   public_subnet_tags = {
     Name = "subnet-public"
   }
 
-  # Private subnets contain resources that do not have public IPs. They have 
+  # Private subnets contain resources that do not have public IPs. They have
   # private IPs and can only interact with resources inside the same network
   # Resources in a private subnet needing internet access require a NAT device
   # private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
@@ -115,7 +130,7 @@ module "vpc" {
   }
 
   # You can enable communication from internet to RDS is via an internet gateway
-  # to provide public access to RDS instance, but is not recommended for 
+  # to provide public access to RDS instance, but is not recommended for
   # production! These parameters are all false so no public access to RDS
   create_database_subnet_group = false
   create_database_subnet_route_table = false
@@ -127,8 +142,8 @@ module "vpc" {
 
   # NAT gateways provide resources in private subnets that do not have
   # public IP address with outbound access to the public Internet or other AWS
-  # resources. NAT gateways are placed in public subnet. Does RDS instance need 
-  # a NAT as it will be placed in private subnet? Access to it will be via a 
+  # resources. NAT gateways are placed in public subnet. Does RDS instance need
+  # a NAT as it will be placed in private subnet? Access to it will be via a
   # bastion server.
   # enable_nat_gateway = false
   # single_nat_gateway = false
@@ -188,11 +203,10 @@ module "rds" {
   owner = data.external.callerUserName.result.userName
   deployment_target = var.deployment_target
 
-  # This variable needs to be overridden on cmd line in order to create an RDS
-  # service by restoring from a snapshot
+  # Needs to be overridden to restore an RDS snapshot
   snapshot_identifier = var.snapshot_identifier
 
-  # For restoring RDS from automated backup
+  # Requires overrride.tf to restore RDS from an automated backup
   restore_to_point_in_time = var.restore_to_point_in_time
 
   vpc_id = module.vpc.vpc_id

--- a/ops/infrastructure/terraform.tf
+++ b/ops/infrastructure/terraform.tf
@@ -38,6 +38,12 @@ variable "gigadb_db_password" {
   description = "Password for PostgreSQL database"
 }
 
+variable "snapshot_identifier" {
+  type = string
+  description = "Snapshot identifier for restoring RDS service"
+  default = null
+}
+
 data "external" "callerUserName" {
   program = ["${path.module}/getIAMUserNameToJSON.sh"]
 }
@@ -175,6 +181,10 @@ module "rds" {
 
   owner = data.external.callerUserName.result.userName
   deployment_target = var.deployment_target
+
+  # This variable needs to be overridden on cmd line in order to create an RDS
+  # service by restoring from a snapshot
+  snapshot_identifier = var.snapshot_identifier
 
   vpc_id = module.vpc.vpc_id
   rds_subnet_ids = module.vpc.database_subnets

--- a/ops/scripts/tf_init.sh
+++ b/ops/scripts/tf_init.sh
@@ -30,10 +30,8 @@ while [[ $# -gt 0 ]]; do
         backup_file=$2
         shift
         ;;
-    --restore)
-        has_restore=true
-        restore=$2
-        shift
+    --restore-backup)
+        has_restore_backup=true
         ;;
     *)
         echo "Invalid option: $1"
@@ -72,10 +70,9 @@ if [ -z $AWS_REGION ];then
   read -p "You need to specify an AWS region: " AWS_REGION
 fi
 
-# Restoring an RDS automated backup requires the restore_to_point_in_time
-# variable with default null value in Terraform to be overridden with a real
-# restore_to_point_in_time configuration code block
-if [ $restore = "rdsbackup" ];then
+# RDS backup restoration requires null restore_to_point_in_time variable in
+# terraform.tf to be overridden with real config code block in override.tf
+if [ "$has_restore_backup" = true ];then
   cp ../../override.tf .
 fi
 

--- a/ops/scripts/tf_init.sh
+++ b/ops/scripts/tf_init.sh
@@ -95,7 +95,7 @@ echo "GITLAB_USERNAME=$GITLAB_USERNAME" >> .init_env_vars
 echo "GITLAB_PRIVATE_TOKEN=$GITLAB_PRIVATE_TOKEN" >> .init_env_vars
 echo "aws_ssh_key=$aws_ssh_key" >> .init_env_vars
 echo "deployment_target=$target_environment" >> .init_env_vars
-echo "backup_file=../../../../gigadb/app/tools/files-url-updater/sql/$backup_file" >> .init_env_vars
+echo "backup_file=$backup_file" >> .init_env_vars
 
 # Update terraform.tfvars file with values from GitLab so Terraform can configure RDS instance
 gigadb_db_database=$(curl -s --header "PRIVATE-TOKEN: $GITLAB_PRIVATE_TOKEN" "$PROJECT_VARIABLES_URL/gigadb_db_database?filter%5benvironment_scope%5d=$target_environment" | jq -r .value)

--- a/ops/scripts/tf_init.sh
+++ b/ops/scripts/tf_init.sh
@@ -26,8 +26,13 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     --backup-file)
-        has_env=true
+        has_backup_file=true
         backup_file=$2
+        shift
+        ;;
+    --restore)
+        has_restore=true
+        restore=$2
         shift
         ;;
     *)
@@ -65,6 +70,13 @@ fi
 
 if [ -z $AWS_REGION ];then
   read -p "You need to specify an AWS region: " AWS_REGION
+fi
+
+# Restoring an RDS automated backup requires the restore_to_point_in_time
+# variable with default null value in Terraform to be overridden with a real
+# restore_to_point_in_time configuration code block
+if [ $restore = "rdsbackup" ];then
+  cp ../../override.tf .
 fi
 
 # url encode gitlab project


### PR DESCRIPTION
# Pull request for issue: #732

This is a pull request for the following functionalities:

* Ability to restore a database snapshot and automated backup into a new RDS instance.

## Changes to the provisioning

When executing` tf_init.sh`, the full path to a backup file created by the `files-url-updater` tool is required. Here is an example prompt and required response:
```
You need to specify a backup file created by the files-url-updater tool: ../../../../gigadb/app/tools/files-url-updater/sql/gigadbv3_20210929_v9.3.25.backup
```

### Creation of snapshots and backups

`rds-instance.tf` has been updated by setting `skip_final_snapshot=false` and providing an expression to create a value for the `final_snapshot_identifier` variable to create a final database snapshot on termination of a RDS instance. 

In addition, `rds-instance.tf` has been updated to automatically create backups between 3-6 am UTC by setting `backup_retention_period=5` days. Because `delete_automated_backups=false`,  automated backups are retained when the RDS instance is deleted.

### Restoration of snapshots and backups

Snapshots can be restored in a new RDS instance by providing a value for `snapshot_identifier` which is null by default, e.g. `snapshot-for-testing` available in the Hong Kong AWS region, on the command-line as follows:
```
$ terraform plan -var snapshot_identifier="snapshot-for-testing"
$ terraform apply -var snapshot_identifier="snapshot-for-testing"
$ terraform refresh
```

Automated backups can either be restored to its latest restorable time or to a specific time. Both require a `restore_to_point_in_time ` configuration block which, in `terraform.tf`, is `null` by default. It is overridden by the presence of an `override.tf` file which contains an actual `restore_to_point_in_time` configuration block:
```
module "rds" {
   restore_to_point_in_time = {
     source_dbi_resource_id = var.source_dbi_resource_id
     restore_time = var.utc_restore_time
     use_latest_restorable_time = var.use_latest_restorable_time
   }
 }
```

This `override.tf` is only copied into the environment directory if a user wants to restore an automated backup by using a `--restore-backup` command line flag:
```
# Without --restore-backup flag, override.tf is not copied into the environment directory
$ ../../../scripts/tf_init.sh --project gigascience/forks/pli888-gigadb-website --env staging --restore-backup
```

Terraform will automatically detect the presence of `override.tf` in the directory and add it to the provisioning process when creating the RDS instance.

The following command line variables are then used to configure the `restore_to_point_in_time` code block. For example, to restore a backup to its latest restorable time:
```
$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var use_latest_restorable_time="true"
```
N.B. `gigadb_db_database` needs to be empty as it will be provided by the backup.

To use the backup to restore to a specific time:
```
$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var utc_restore_time="2021-10-27T06:02:12+00:00"
```

N.B. `source_dbi_resource_id` is the identifier for the backup you want to restore and these identifiers can be listed by executing:
```
$ aws rds describe-db-instance-automated-backups
```

## Changes to the documentation

* `SETUP_CI_CD_PIPELINE.md` has been updated with the steps to perform an RDS restoration using snapshots and backups.
* `policy-ec2.md` and `policy-rds.md` have been updated with the latest version of the policies currently used in the GigaDB AWS infrastructure.

---

## Procedure for restoring database snapshot and backups

We assume there is an existing RDS instance that we want to terminate and replace with a new RDS instance containing data that has been restored from a PostgreSQL snapshot or backup.

### Restoration of database snapshots
```
# Go to environment directory
$ cd <path>/gigadb-website/ops/infrastructure/envs/staging

# Terminate existing RDS service
$ terraform destroy --target module.rds

# Restore database snapshot in Hong Kong AWS region
$ terraform plan -var snapshot_identifier="snapshot-for-testing"
$ terraform apply -var snapshot_identifier="snapshot-for-testing"
$ terraform refresh
```

Now check the endpoint of your new RDS instance as shown in the AWS console is the same as that already defined for your Gitlab  `gigadb_db_host` variable.

Dataset 100043 will have a title that is specific to this snapshot - https://your-staging-gigadb/dataset/100043

### Restoration of database backups
```
# Go to environment directory
$ cd <path>/gigadb-website/ops/infrastructure/envs/staging

# Terminate existing RDS service
$ terraform destroy --target module.rds

# Copy override.tf to staging environment by using --restore-backup flag
$ ../../../scripts/tf_init.sh --project gigascience/forks/pli888-gigadb-website --env staging --restore-backup

# Backups can either be restored to its latest restorable time or to a specific
# time. Test the following in AWS Hong Kong region

# To restore to latest restorable time - need to override database name as this 
# will come from the backup
$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var use_latest_restorable_time="true"

# To restore to specific time in backup - need to override database name as this 
# will come from the backup
$ terraform apply -var source_dbi_resource_id="db-6GQU4LWFBZI34AOR5BW2MEQFLU" -var gigadb_db_database="" -var utc_restore_time="2021-10-27T06:02:12+00:00"
```

Now check the endpoint of your new RDS instance as shown in the AWS console is the same as that already defined for your Gitlab  `gigadb_db_host` variable.

Dataset 100016 will have a title that is specific to this backup - https://your-staging-gigadb/dataset/100016