### PR TITLE
Ports audit (for task gigascience/gigadb-website#820)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,19 @@
+# Ports
+
+## Used ports
+
+| Port number | Protocol | open on servers |
+| --- | --- | --- |
+| 80 | HTTP | web | 
+| 443 | HTTPS | web |
+| 2376 | Docker | web |
+| 9000 | PHP-FPM | application |
+| 5432 | PostgresQL | AWS RDS |
+| 22 | SSH | bastion |
+| 21 | FTP | CNGB FTP |
+
+## Scanning for open ports
+
+```
+$ docker-compose run --rm test bash -c 'nc -z -v <host> 1-65535' | grep succeeded
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,19 +1,66 @@
 # Ports
 
-## Used ports
+##  Ports used by GigaDB on its infrastructure
 
-| Port number | Protocol | open on servers |
+| Port number | Protocol/Service | open on servers |
 | --- | --- | --- |
-| 80 | HTTP | web | 
-| 443 | HTTPS | web |
-| 2376 | Docker | web |
-| 9000 | PHP-FPM | application |
+| 80 | HTTP | dockerhost | 
+| 443 | HTTPS | dockerhost |
+| 2375 | Docker | dockerhost (local dev only) |
+| 2376 | Docker | dockerhost (AWS deployments only) |
+| 9000 | PHP-FPM | dockerhost (not exposed to host on AWS deployments) |
+| 9009 | Portainer | dockerhost |
 | 5432 | PostgresQL | AWS RDS |
-| 22 | SSH | bastion |
+| 22 | sshd | dockerhost and bastion |
 | 21 | FTP | CNGB FTP |
+
+
+## Ports open by Operating system services in Centos 8.4
+
+| Port number | Protocol/Service | open on servers |
+| --- | --- | --- |
+| 111 | rpcbind | dockerhost and bastion | 
+| 323 (UDP) | chronyd | dockerhost and bastion |
+| 22 | sshd | dockerhost and bastion |
 
 ## Scanning for open ports
 
+On local dev environment one can use netcat
 ```
 $ docker-compose run --rm test bash -c 'nc -z -v <host> 1-65535' | grep succeeded
 ```
+>Note: upper boundary is 65535 because port number is stored in a 16-bit field in TCP packets
+
+For testing on AWS deployment, one can ssh into dockerhost and/or bastion and run the scan from there.
+However in that environment ``netcat`` is very slow, and it's better to use ``nmap``[1] instead.
+
+
+```
+$ sudo dnf install nmap
+$ nmap -Pn <host>
+```
+in ``<host>``, do use the private IP address of the host to be audited, so that the network traffic 
+stays within the VPC.
+
+
+The above command will scan the top 1000s most common ports registered with IANA [2].
+If a protocol/service is too recent (e.g: Docker), it won't be in there.
+
+In such cases, use ``-p`` parameters to pass on a list of ranges.
+
+```
+$ nmap -Pn -p 2300-2400,8000-11000 11.99.0.252
+```
+
+However, the most reliable way to know what ports are open on a linux server, 
+is to ssh into the target host and run the system command ``ss`` [3]
+
+```
+$ ss -tunlp
+```
+
+[1] https://nmap.org/book/man-port-specification.html
+
+[2] http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
+
+[3] https://www.linux.com/topic/networking/introduction-ss-command/

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-.b_gigadb:
+b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-b_gigadb:
+.b_gigadb:
   stage: build for test
   script:
     # Load Base image
@@ -93,7 +93,7 @@ b_gigadb:
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/js:latest
     - docker-compose run --rm config
     - docker-compose run --rm fuw-config
-    - docker-compose run --rm application composer install
+    - docker-compose run --rm test composer install
     - docker-compose run --rm console bash -c "cd /app && composer update"
     - docker-compose run --rm console bash -c 'cd /gigadb-apps/worker/file-worker/ && composer update'
     - docker-compose run --rm js npm install


### PR DESCRIPTION
## Scanning for ports associated with known services (IANA)

>Note: I've redacted IPs and hostnames

### Scanning docker host:

```
[me@ip-11-99-0-252 ~]$ nmap -Pn 11.99.0.98
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 09:57 UTC
Nmap scan report for ip-11-99-0-98.ap-east-1.compute.internal (10.99.0.98)
Host is up (0.00033s latency).
Not shown: 996 filtered ports
PORT      STATE  SERVICE
22/tcp    open   ssh
80/tcp    open   http
443/tcp   open   https
30000/tcp closed ndmps

Nmap done: 1 IP address (1 host up) scanned in 4.77 seconds
```

### Scanning bastion:

```
[me@ip-11-99-0-98 ~]$ nmap -Pn 11.99.0.252
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 09:43 UTC
Nmap scan report for ip-11-99-0-252.ap-east-1.compute.internal (10.99.0.252)
Host is up (0.00055s latency).
Not shown: 999 filtered ports
PORT   STATE SERVICE
22/tcp open  ssh

Nmap done: 1 IP address (1 host up) scanned in 6.56 seconds
```


## Scanning for ports typical for containers and application servers

### Scanning dockerhost

```
[me@ip-11-99-0-252 ~]$ nmap -Pn -p 2300-2400,8000-11000 11.99.0.98
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 14:28 UTC
Nmap scan report for ip-11-99-0-98.ap-east-1.compute.internal (10.99.0.98)
Host is up (0.00028s latency).
Not shown: 2100 filtered ports
PORT     STATE  SERVICE
2376/tcp open   docker
9021/tcp closed panagolin-ident

Nmap done: 1 IP address (1 host up) scanned in 169.08 seconds
```

### Scanning bastion

```
[me@ip-11-99-0-98 ~]$ nmap -Pn -p 2300-2400,8000-11000 11.99.0.252
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 14:15 UTC
Nmap scan report for ip-11-99-0-252.ap-east-1.compute.internal (10.99.0.252)
Host is up.
All 2102 scanned ports on ip-11-99-0-252.ap-east-1.compute.internal (10.99.0.252) are filtered

Nmap done: 1 IP address (1 host up) scanned in 423.68 seconds
```

The problem with this approach is that nmap is not seeing  all the open ports.
I think nmap works by taking best guess based on how the target responds.

A more reliable and authoritative method is to to the scan on the target using builtin linux tools.

Below are the results. 

>Note 1:  that TPC port 111 is open by default on Centos 8.4 and is used by ``rpcbind``.
>Note 2:  UDP port 323 is open by default on Centos 8.4 and is used by ``chronyd``

### Scanning docker host using ss

```
[me@ip-11-99-0-98 ~]$ ss -tunlp
Netid            State             Recv-Q            Send-Q                       Local Address:Port                       Peer Address:Port           Process            
udp              UNCONN            0                 0                                  0.0.0.0:111                             0.0.0.0:*                                 
udp              UNCONN            0                 0                                127.0.0.1:323                             0.0.0.0:*                                 
udp              UNCONN            0                 0                                     [::]:111                                [::]:*                                 
udp              UNCONN            0                 0                                    [::1]:323                                [::]:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:22                              0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:443                             0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:8000                            0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:111                             0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:80                              0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:9009                            0.0.0.0:*                                 
tcp              LISTEN            0                 128                                   [::]:22                                 [::]:*                                 
tcp              LISTEN            0                 128                                   [::]:443                                [::]:*                                 
tcp              LISTEN            0                 128                                   [::]:8000                               [::]:*                                 
tcp              LISTEN            0                 128                                      *:2376                                  *:*                                 
tcp              LISTEN            0                 128                                   [::]:111                                [::]:*                                 
tcp              LISTEN            0                 128                                   [::]:80                                 [::]:*                                 
tcp              LISTEN            0                 128                                   [::]:9009                               [::]:*       

```

### Scanning bastion using ss

```
[me@ip-11-99-0-252 ~]$ ss -tunlp
Netid            State             Recv-Q            Send-Q                       Local Address:Port                       Peer Address:Port           Process            
udp              UNCONN            0                 0                                  0.0.0.0:111                             0.0.0.0:*                                 
udp              UNCONN            0                 0                                127.0.0.1:323                             0.0.0.0:*                                 
udp              UNCONN            0                 0                                     [::]:111                                [::]:*                                 
udp              UNCONN            0                 0                                    [::1]:323                                [::]:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:22                              0.0.0.0:*                                 
tcp              LISTEN            0                 128                                0.0.0.0:111                             0.0.0.0:*                                 
tcp              LISTEN            0                 128                                   [::]:22                                 [::]:*                                 
tcp              LISTEN            0                 128                                   [::]:111                                [::]:*                                 

```


### Scanning RDS instance

Since we can't SSH on the RDS instance, we will have to rely on ``nmap``,  but there's less risk as this a part of the higher level AWS SaaS (Platform As a Service), the security of which is part of said service.

```
[me@ip-11-99-0-252 ~]$ nmap -Pn -p 1-900,2300-2400,5000-6000,8000-11000 rds-server-staging-user.cfkc0cfgsdhebc20ii.ap-east-1.rds.amazonaws.com
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 15:25 UTC
Nmap scan report for rds-server-staging-user.cfkc0cfgsdhebc20ii.ap-east-1.rds.amazonaws.com (10.99.6.73)
Host is up (0.00038s latency).
rDNS record for 11.99.6.73: ip-11-99-6-73.ap-east-1.compute.internal
Not shown: 4002 filtered ports
PORT     STATE SERVICE
5432/tcp open  postgresql

Nmap done: 1 IP address (1 host up) scanned in 45.12 seconds
[me@ip-11-99-0-252 ~]$ nmap -Pn --top-ports 11.00 rds-server-staging-user.cfkc0cfgsdhebc20ii.ap-east-1.rds.amazonaws.com
Starting Nmap 7.70 ( https://nmap.org ) at 2021-11-28 15:29 UTC
Nmap scan report for rds-server-staging-user.cfkc0cfgsdhebc20ii.ap-east-1.rds.amazonaws.com (10.99.6.73)
Host is up (0.00034s latency).
rDNS record for 11.99.6.73: ip-11-99-6-73.ap-east-1.compute.internal
Not shown: 8305 filtered ports
PORT     STATE SERVICE
5432/tcp open  postgresql

Nmap done: 1 IP address (1 host up) scanned in 54.40 seconds
```

## Changes

* I have added ``docs/SECURITY.md`` with the list of ports and details on the tools used.	

## Conclusion

On this branch at the time of this comment, there's no unexpected ports open on the two EC2 instances that are created by our provisioning process, nor on the RDS instance.

