### PR TITLE
Fix SQL related server error on dataset pages after second deployment on same provisioned infrastructure

### DIFF
--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -212,7 +212,7 @@ base_images:
     when: on_failure
     expire_in: 1 week
 
-.build_staging:
+build_staging:
   variables:
     GIGADB_ENV: "staging"
   extends: .pb_gigadb
@@ -221,7 +221,7 @@ base_images:
     name: "staging"
     url: $REMOTE_HOME_URL
 
-.build_live:
+build_live:
   variables:
     GIGADB_ENV: "live"
   extends: .pb_gigadb

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -212,7 +212,7 @@ base_images:
     when: on_failure
     expire_in: 1 week
 
-build_staging:
+.build_staging:
   variables:
     GIGADB_ENV: "staging"
   extends: .pb_gigadb
@@ -221,7 +221,7 @@ build_staging:
     name: "staging"
     url: $REMOTE_HOME_URL
 
-build_live:
+.build_live:
   variables:
     GIGADB_ENV: "live"
   extends: .pb_gigadb

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -57,9 +57,9 @@
     # Run database migrations if any
     - 'MIGRATION_STATUS="$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")"'
     - echo "$MIGRATION_STATUS"
-    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
-    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
-    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -55,10 +55,10 @@
     # deploy the web container once the application servers are up
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --connectionID=db --interactive=0
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
+    - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1)'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -55,7 +55,7 @@
     # deploy the web container once the application servers are up
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
-    - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
+    - 'MIGRATION_STATUS="$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")"'
     - echo "$MIGRATION_STATUS"
     - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -56,6 +56,7 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
     - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
+    - echo "$MIGRATION_STATUS"
     - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
     - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -57,9 +57,9 @@
     # Run database migrations if any
     - 'MIGRATION_STATUS="$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")"'
     - echo "$MIGRATION_STATUS"
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -57,6 +57,7 @@
     # Run database migrations if any
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate mark 000000_000000 --connectionID=db --interactive=0
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -56,8 +56,7 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
     - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
-    - echo $MIGRATION_STATUS
-    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml ps
+    - MIGRATION_STATUS="$MIGRATION_STATUS"
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -56,10 +56,9 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
     - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
-    - MIGRATION_STATUS="$MIGRATION_STATUS"
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
-    - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
+    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
+    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
+    - '[[ "$MIGRATION_STATUS" != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'
     # post-install script to run
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm less
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic generatefiletypes

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -56,6 +56,8 @@
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
     - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
+    - echo $MIGRATION_STATUS
+    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml ps
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'

--- a/ops/pipelines/gigadb-deploy-jobs.yml
+++ b/ops/pipelines/gigadb-deploy-jobs.yml
@@ -55,7 +55,7 @@
     # deploy the web container once the application servers are up
     - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml up -d web
     # Run database migrations if any
-    - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application ./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1)'
+    - 'MIGRATION_STATUS=$(docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm application bash -c "./protected/yiic migrate new --migrationPath=application.migrations.schema --interactive=0 | tail -1")'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes'
     - '[[ $MIGRATION_STATUS != *up-to-date* ]] && docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0'


### PR DESCRIPTION
PR to fix issue #830

## Problem

Immediately after provisioning the infrastructure, on a gitlab pipeline, when pressing a button to trigger a deployment job for staging (``sd_gigadb``) or live (``ld_gigadb``), the application is successfully deployed the first time. If we trigger the same job a second time, the application is still deployed but the resulting web site show a server error with the following SQL related error when navigating to a dataset page.
It doesn't matter whether we rebuild the image (by triggering a build job for that environment) before triggering  the second deployment job or not.

```
CDbCommand failed to execute the SQL statement: SQLSTATE[42601]: Syntax error: 7 ERROR: zero-length delimited identifier at or near """" LINE 1: ... "t1_c3" FROM "file_format" "format" WHERE ("format".""=$1)
^. The SQL statement executed was: SELECT "format"."id" AS "t1_c0", "format"."name" AS "t1_c1", "format"."description" AS "t1_c2", "format"."edam_ontology_id" AS "t1_c3" FROM "file_format" "format" WHERE ("format".""=:ypl0). Bound with :ypl0=37
```


## Cause 

It's because of those lines from ``gigadb-deploy-jobs.yml`` related to running database migrations:


```
    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropconstraints
    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic custommigrations dropindexes
    - docker-compose --tlsverify -H=$REMOTE_DOCKER_HOST -f ops/deployment/docker-compose.production-envs.yml run --rm  application ./protected/yiic migrate --migrationPath=application.migrations.schema --interactive=0
```

The first time a deployment job is triggered, the migration level is not recorded, and the schema migration runs and complete after the database constraints and indexes have been dropped.
The second time a deployment job, the migration level is now recorded in the database so the schema migration is not run but the database constraints are still dropped,
so the database is in a state where foreign constraints are not defined which will cause join queries (like those performed by Yii lookup functions) to fail.

## Fix


One option is to reset migration level: since all the constraints need to be dropped, we need to reset migration level, so that the database schema migration can run and re-establish them.

However we are losing the benefit of using migrations, which is the incremental update of the schema as necessary and required by changes to the application.

The proper approach is to perform schema migrations and dropping of constraints and indexes if and only if there are new migrations to run.

In order to do that, we save into a variable (``MIGRATION_STATUS``) the output of executing ``yiic migrate new`` and then prefix the three lines above with a test (``[[ -z "`echo $MIGRATION_STATUS | grep "up-to-date"`" ]]``) on the output that will allows their execution only if the string saying that the migrations are up-to-date is not present in that variable.


