### PR TITLE
Fix CI test job failure when setting up database in up.sh

### DIFF
--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-.b_gigadb:
+b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -26,9 +26,9 @@ t_gigadb:
     when: always
     expire_in: 1 week
   script:
-    # appending production variables at the end of the .env and .secrets
-    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" >> $APPLICATION/.env
-    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
+    # appending dev variables at the end of the .env and .secrets
+    - env | grep "^HOME_URL" >> $APPLICATION/.env
+    - env | grep "^GIGADB_" >> $APPLICATION/.secrets
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/console:latest || true

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,6 +1,4 @@
 t_gigadb:
-  variables:
-    HOME_URL: http://gigadb.gigasciencejournal.com:9170
   stage: test
   cache:
     paths:

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,4 @@
-.t_gigadb:
+t_gigadb:
   stage: test
   cache:
     paths:

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -26,6 +26,9 @@ t_gigadb:
     when: always
     expire_in: 1 week
   script:
+    # appending production variables at the end of the .env and .secrets
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" >> $APPLICATION/.env
+    - env | grep -v "SAST" | grep -iE "^(staging_|remote_)" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" | grep -viE "tlsauth">> $APPLICATION/.secrets
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/application:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/test:latest || true
     - docker pull registry.gitlab.com/$CI_PROJECT_PATH/console:latest || true
@@ -45,4 +48,5 @@ t_gigadb:
     - ./up.sh
     - cd $APPLICATION
     - ./tests/all_and_coverage
-
+  environment:
+    name: dev

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,6 +1,6 @@
 t_gigadb:
-    variables:
-      HOME_URL: http://gigadb.gigasciencejournal.com:9170
+  variables:
+    HOME_URL: http://gigadb.gigasciencejournal.com:9170
   stage: test
   cache:
     paths:

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,6 @@
 t_gigadb:
+    variables:
+      HOME_URL: http://gigadb.gigasciencejournal.com:9170
   stage: test
   cache:
     paths:


### PR DESCRIPTION
The test job is failing with error:

```
+ ./ops/scripts/setup_devdb.sh dev
The PORTAINER_BCRYPT variable is not set. Defaulting to a blank string.
ERROR:  database "gigadb" already exists
The PORTAINER_BCRYPT variable is not set. Defaulting to a blank string.
The PORTAINER_BCRYPT variable is not set. Defaulting to a blank string.
Yii Migration Tool v1.0 (based on Yii v1.1.20)
CDbException: CDbConnection failed to open the DB connection: SQLSTATE[08006] [7] could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"? in /var/www/vendor/yiisoft/yii/framework/db/CDbConnection.php:399
Stack trace:

```

The cause is that the ``protected/config/db.json`` configuration file generated by ``/ops/scripts/generate_config.sh`` doesn't have the values populated for the database connection strings keys.


This regression is likely the combined result of: 
  * changing to use ``up.sh`` for setting up the application for automated tests
  * reorganising GitLab variables
  * configuring GitLab variables to be bound to specific environments
  * disabling tests on CI while we test provisioning but that's also when the above points were done

The variables needed to populate the config file ``protected/config/db.json`` are:

| Key | value | environment | protected | masked |
| --- | --- | --- | --- | --- |
| GIGADB_DB | gigadb | dev | no | no |
| GIGADB_HOST | database | dev | no | no | 
| GIGADB_PASSWORD | vagrant | dev | no | no |
| GIGADB_USER | gigadb | dev | no | no |


Setting up the above variables is enough for local deployment, but not on CI.
We also need for the test job ``t_gigadb`` to access a ``.secrets`` that has the above key/value pairs in it.

This is obtained with two changes:

* Configure ``t_gigadb`` job to be part of the gitlab environment ``dev``
* In the job definition, capture the environment variables and **append** them to the ``.env`` and ``.secrets`` file generated in the previous (build) stage of the pipeline


Although the above is enough to fix the main issue, another problem occurred further down the execution of the test job:

```
There was 1 failure:
---------
1) UploadFactoryTest: Generate ftp link
 Test  tests/unit/UploadFactoryTest.php:testGenerateFTPLink
Failed asserting that two strings are equal.
- Expected | + Actual
@@ @@
-'http://gigadb.gigasciencejournal.com:9170/filedrop/300001/somefile.fq'
+'gigadb.gigasciencejournal.com/filedrop/300001/somefile.fq'
#1  /app/console/tests/unit/UploadFactoryTest.php:70
#2  console\tests\UploadFactoryTest->testGenerateFTPLink
FAILURES!
Tests: 10, Assertions: 16, Failures: 1.
```

This was solved (and made possible by the previous fix) by setting an environment variable with the appropriate value in GitLab variables:

| Key | value | environment | protected | masked |
| --- | --- | --- | --- | --- |
| HOME_URL | http://gigadb.gigasciencejournal.com:9170 | dev | no | no |
