### PR TITLE
Aws security test staging/live containers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,12 +80,12 @@ cache:
       - gigadb/app/client/web/node_modules
 
 before_script:
-  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
-  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
-  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
-  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && apk add --no-cache py-pip bash'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning* ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning* ]] && apk add --no-cache py-pip bash'
   # Pin docker-compose version to stop installation error
-  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && pip install docker-compose~=1.23.0'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning* ]] && pip install docker-compose~=1.23.0'
 
 sd_gigadb:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ variables:
 
 include:
   - template: Security/SAST.gitlab-ci.yml
+  - template: Security/Container-Scanning.gitlab-ci.yml
   - local: "ops/pipelines/gigadb-build-jobs.yml"
   - local: "ops/pipelines/gigadb-test-jobs.yml"
   - local: "ops/pipelines/gigadb-conformance-security-jobs.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,12 +80,12 @@ cache:
       - gigadb/app/client/web/node_modules
 
 before_script:
-  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
-  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
-  - '[[ $CI_JOB_NAME != *sast* ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
-  - '[[ $CI_JOB_NAME != *sast* ]] && apk add --no-cache py-pip bash'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep "^CI_" > $APPLICATION/.ci_env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -viE "(password|email|tester|secret|key|user|app_id|client_id|token|tls)" > $APPLICATION/.env'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && env | grep -v "SAST" | grep -v "^DOCKER" | grep -v "^CI" | grep -v "^LOCAL_COMPOSE" | grep -v "^GITLAB" | grep -v "==" | grep -E "^[a-zA-Z0-9_]+=.+" | grep -v "ANALYTICS_PRIVATE_KEY" | grep -viE "tls" | grep -iE "(password|email|tester|secret|key|user|app_id|client_id|token)" > $APPLICATION/.secrets'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && apk add --no-cache py-pip bash'
   # Pin docker-compose version to stop installation error
-  - '[[ $CI_JOB_NAME != *sast* ]] && pip install docker-compose~=1.23.0'
+  - '[[ $CI_JOB_NAME != *sast* ]] && [[ $CI_JOB_NAME != container_scanning ]] && pip install docker-compose~=1.23.0'
 
 sd_gigadb:
   variables:

--- a/ops/pipelines/gigadb-build-jobs.yml
+++ b/ops/pipelines/gigadb-build-jobs.yml
@@ -24,7 +24,7 @@ base_images:
       - nginx-1_21-alpine.tar
       - node-14-buster.tar
 
-b_gigadb:
+.b_gigadb:
   stage: build for test
   script:
     # Load Base image

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -100,9 +100,6 @@ spotbugs-sast:
 container_scanning:
   stage: conformance and security
   variables:
-    GIT_STRATEGY: fetch
-    DOCKER_USER: gitlab-ci-token
-    DOCKER_PASSWORD: $CI_JOB_TOKEN
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:staging
     SECURE_LOG_LEVEL: debug
     CS_SEVERITY_THRESHOLD: critical
-    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV && registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -104,3 +104,4 @@ container_scanning:
     DOCKER_USER: gitlab-ci-token
     DOCKER_PASSWORD: $CI_JOB_TOKEN
     SECURE_LOG_LEVEL: debug
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/application:latest

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -103,3 +103,18 @@ container_scanning:
     DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:staging
     SECURE_LOG_LEVEL: debug
     CS_SEVERITY_THRESHOLD: critical
+
+container_scanning_2:
+  extends: container_scanning
+  variables:
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_app:staging
+
+container_scanning_3:
+  extends: container_scanning
+  variables:
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:live
+
+container_scanning_4:
+  extends: container_scanning
+  variables:
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_app:live

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -103,3 +103,4 @@ container_scanning:
     GIT_STRATEGY: fetch
     DOCKER_USER: gitlab-ci-token
     DOCKER_PASSWORD: $CI_JOB_TOKEN
+    SECURE_LOG_LEVEL: debug

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -96,3 +96,10 @@ spotbugs-sast:
   stage: conformance and security
   variables:
     SAST_DISABLED: "true"
+
+container_scanning:
+  stage: conformance and security
+  variables:
+    GIT_STRATEGY: fetch
+    DOCKER_USER: gitlab-ci-token
+    DOCKER_PASSWORD: $CI_JOB_TOKEN

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -104,4 +104,5 @@ container_scanning:
     DOCKER_USER: gitlab-ci-token
     DOCKER_PASSWORD: $CI_JOB_TOKEN
     SECURE_LOG_LEVEL: debug
-    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/application:latest
+    CS_SEVERITY_THRESHOLD: CRITICAL
+      DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV && registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV

--- a/ops/pipelines/gigadb-conformance-security-jobs.yml
+++ b/ops/pipelines/gigadb-conformance-security-jobs.yml
@@ -104,5 +104,5 @@ container_scanning:
     DOCKER_USER: gitlab-ci-token
     DOCKER_PASSWORD: $CI_JOB_TOKEN
     SECURE_LOG_LEVEL: debug
-    CS_SEVERITY_THRESHOLD: CRITICAL
-      DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV && registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV
+    CS_SEVERITY_THRESHOLD: critical
+    DOCKER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH/production_web:$GIGADB_ENV && registry.gitlab.com/$CI_PROJECT_PATH/production_app:$GIGADB_ENV

--- a/ops/pipelines/gigadb-test-jobs.yml
+++ b/ops/pipelines/gigadb-test-jobs.yml
@@ -1,4 +1,4 @@
-t_gigadb:
+.t_gigadb:
   stage: test
   cache:
     paths:


### PR DESCRIPTION
This PR for [gigascience #822](https://github.com/gigascience/gigadb-website/issues/822).

### Task 1: Verify that docker remote control of staging and live web site is taking place using client cert authentication
1. On staging server
```
user@dev-computer: % ssh -i ~/.ssh/<CustomPrivateKey>.pem -o ProxyCommand="ssh -W %h:%p -i ~/.ssh/<CustomPrivateKey>.pem centos@<bastion_public_ip>" centos@ec2-<docker_public_ip>.<region>.compute.amazonaws.com
[centos@ip-10-99-0-188 ~]$ ls
app_data
[centos@ip-10-99-0-188 ~]$ docker ps
CONTAINER ID   IMAGE                                                                                COMMAND                  CREATED       STATUS       PORTS                                                                                            NAMES
732e957720d3   portainer/portainer-ce:latest                                                        "/portainer -H unix:…"   3 hours ago   Up 3 hours   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 9443/tcp, 0.0.0.0:9009->9000/tcp, :::9009->9000/tcp   kencho-gigadb-website_portainer_1
4768f62dcc67   registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_web:staging   "/docker-entrypoint.…"   3 hours ago   Up 3 hours   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp                         kencho-gigadb-website_web_1
54ceb5461f1c   registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_app:staging   "docker-php-entrypoi…"   3 hours ago   Up 3 hours   9000/tcp                                                                                         kencho-gigadb-website_application_1
[centos@ip-10-99-0-188 ~]$ 

```
2. On live server
```
user@dev-computer: % ssh -i ~/.ssh/<CustomPrivateKey>.pem -o ProxyCommand="ssh -W %h:%p -i ~/.ssh/<CustomPrivateKey>.pem centos@<bastion_public_ip>" centos@ec2-<docker_public_ip>.<region>.compute.amazonaws.com
[centos@ip-10-99-0-20 ~]$ ls
app_data
[centos@ip-10-99-0-20 ~]$ docker ps
CONTAINER ID   IMAGE                                                                             COMMAND                  CREATED         STATUS         PORTS                                                                                            NAMES
f57a25fdd706   portainer/portainer-ce:latest                                                     "/portainer -H unix:…"   3 minutes ago   Up 3 minutes   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 9443/tcp, 0.0.0.0:9009->9000/tcp, :::9009->9000/tcp   kencho-gigadb-website_portainer_1
8b47dcf68a21   registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_web:live   "/docker-entrypoint.…"   5 minutes ago   Up 5 minutes   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp                         kencho-gigadb-website_web_1
a180228306ad   registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_app:live   "docker-php-entrypoi…"   5 minutes ago   Up 5 minutes   9000/tcp                                                                                         kencho-gigadb-website_application_1
[centos@ip-10-99-0-20 ~]$ 
```
### Task 2: Run ``docker scan`` on the two images (application and web) and create PBI (product backlog item) for future implementation of  recommendations
Since `docker scan` is only available with docker desktop, the other way round is to implement `container_scanning` in gitlab CI/CD pipeline, the official doc could be found at [here](https://docs.gitlab.com/ee/user/application_security/container_scanning/index.html#running-the-standalone-container-scanning-tool). 
However, the multiple images scanning of gitlab container scanning tool is [still under development](https://gitlab.com/groups/gitlab-org/-/epics/3139), it could scan all the images, but if images found to have the  same vulnerability, the pipeline security tab would only show one from either of the images, here is the [deep investigation of this problem](https://gitlab.com/gitlab-org/gitlab/-/issues/6946#note_308554624).
To be short, for example, the following vulnerabilities found in both [registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_web:live](https://gitlab.com/gigascience/forks/kencho-gigadb-website/-/jobs/1813999598) and [registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_web:staging](https://gitlab.com/gigascience/forks/kencho-gigadb-website/-/jobs/1813999594):
|   STATUS   |      CVE SEVERITY       | PACKAGE NAME | PACKAGE VERSION |                            CVE DESCRIPTION   |           
| ---------- | ---------- | ---------- | ---------- | ---------- |
| Unapproved | Critical CVE-2021-22945 |     curl     |    7.78.0-r0    | When sending data to an MQTT server, libcurl <= 7.73.0 and 7.78.0 could in some circumstances erroneously keep a pointer to an already freed memory area and both use that again in a subsequent call to send data and also free it *again*.  |
| Unapproved | Critical CVE-2021-22945 |   libcurl    |    7.78.0-r0    | When sending data to an MQTT server, libcurl <= 7.73.0 and 7.78.0 could in some circumstances erroneously keep a pointer to an already freed memory area and both use that again in a subsequent call to send data and also free it *again*. |

But, only `registry.gitlab.com/gigascience/forks/kencho-gigadb-website/production_web:staging`'s vulnerabilities could be found in [security tab](https://gitlab.com/gigascience/forks/kencho-gigadb-website/-/pipelines/415210904/?reportType=CONTAINER_SCANNING). It is because each `container_scanning` section would produce one ``gl-container-scanning-report.json`` report, So when it comes time to merge the two separate reports which both contain same vulnerability,  a race condition occurs, and whichever identifier is encountered first will win, and the subsequent occurrence of the vulnerability will be skipped.

This is the [video walkthrough](https://www.youtube.com/watch?v=iiYrvEPT5Fo) created by gitlab on this reported issue. 

### PBI


### Alternatives
1. https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html

### reference
1. https://forum.gitlab.com/t/container-scanning-for-multiple-images/27348
2. https://gitlab.com/gitlab-org/security-products/analyzers/klar/-/blob/efa8e63368df8f2a64c9b395ac913e40ce3f52a2/docs/process-flow.md
3. https://gitlab.com/gitlab-org/gitlab/-/issues/208758