### PR TITLE
Pass in backup date variable to bastion playbook

### DIFF
--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -57,28 +57,24 @@ if [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${thedate}_v${version}.backup
   loadStatus=$?
-  exit
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
   loadStatus=$?
-  exit
 elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
   loadStatus=$?
-  exit
 else
   echo "Loading default backup /home/centos/database_bootstrap.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
   loadStatus=$?
-  exit
 fi
 
 # Load the specific dump in RDS using native postgresql client
@@ -88,27 +84,23 @@ if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${backupDate}_v${version}.backup
   loadStatus=$?
-  exit
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
   loadStatus=$?
-  exit
 elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
   loadStatus=$?
-  exit
 else
   echo "Loading default backup /home/centos/database_bootstrap.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
   loadStatus=$?
-  exit
 fi
 exit $loadStatus

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -57,24 +57,28 @@ if [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${thedate}_v${version}.backup
   loadStatus=$?
+  exit
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
   loadStatus=$?
+  exit
 elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
   loadStatus=$?
+  exit
 else
   echo "Loading default backup /home/centos/database_bootstrap.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
   loadStatus=$?
+  exit
 fi
 
 # Load the specific dump in RDS using native postgresql client
@@ -84,23 +88,27 @@ if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${backupDate}_v${version}.backup
   loadStatus=$?
+  exit
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
   loadStatus=$?
+  exit
 elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
   loadStatus=$?
+  exit
 else
   echo "Loading default backup /home/centos/database_bootstrap.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
   loadStatus=$?
+  exit
 fi
 exit $loadStatus

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -34,12 +34,12 @@ else
 fi
 
 # Convert backup using legacy postgresql client
-if [[ $downloadLatestRestoreStatus -eq 0 ]];then
+if [[ $downloadLatestRestoreStatus -eq 0 && -z $downloadSpecificRestoreStatus ]];then
   docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${latest}_v${version}.backup
   convertStatus=$?
 fi
 
-if [[ $downloadSpecificRestoreStatus -eq 0 ]];then
+if [[ $downloadSpecificRestoreStatus -eq 0 && -z $downloadLatestRestoreStatus ]];then
   docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${backupDate}_v${version}.backup
   convertStatus=$?
 fi

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -17,7 +17,6 @@ docker-compose logs pg9_3
 latest=$(date --date="1 days ago" +"%Y%m%d")
 twoDaysAgo=$(date --date="2 days ago" +"%Y%m%d")
 threeDaysAgo=$(date --date="3 days ago" +"%Y%m%d")
-thedate=${1:-$latest}
 backupDate="$1"
 
 # Default converted backup (from Ansible properties) and legacy postgres version

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -25,7 +25,7 @@ defaultDB="/home/centos/database_bootstrap.backup"
 version=$(docker-compose run --rm updater psql --version | cut -d' ' -f 3 | tr -d '\n\r' )
 
 # Run files-url-updater
-if [[ $backupDate -eq "latest" ]];then
+if [[ -z $backupDate || $backupDate -eq "latest" ]];then
   echo yes | docker-compose run --rm updater ./yii dataset-files/download-restore-backup --latest
   downloadLatestRestoreStatus=$?
 else
@@ -35,7 +35,7 @@ fi
 
 # Convert backup using legacy postgresql client
 if [[ $downloadLatestRestoreStatus -eq 0 ]];then
-  docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${thedate}_v${version}.backup
+  docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${latest}_v${version}.backup
   convertStatus=$?
 fi
 
@@ -52,10 +52,10 @@ export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOS
 
 # Load the latest dump in RDS using native postgresql client
 if [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
-  echo "Loading gigadbv3_${thedate}_v${version}.backup"
+  echo "Loading gigadbv3_${latest}_v${version}.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${thedate}_v${version}.backup
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${latest}_v${version}.backup
   loadStatus=$?
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
@@ -76,6 +76,7 @@ else
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
   loadStatus=$?
 fi
+exit $loadStatus
 
 # Load the specific dump in RDS using native postgresql client
 if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -49,40 +49,18 @@ docker-compose down -v
 # Terminate other connections to RDS instance
 export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='gigadb';"
 
-# Load the latest dump in RDS using native postgresql client
-if [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
-  echo "Loading gigadbv3_${latest}_v${version}.backup"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${latest}_v${version}.backup
-  loadStatus=$?
-elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
-  echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
-  loadStatus=$?
-elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
-  echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
-  loadStatus=$?
-else
-  echo "Loading default backup /home/centos/database_bootstrap.backup"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
-  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
-  loadStatus=$?
-fi
-exit $loadStatus
-
-# Load the specific dump in RDS using native postgresql client
-if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
+# Load the backup dump to RDS using native postgresql client
+if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 && -z $downloadLatestRestoreStatus ]];then
   echo "Loading gigadbv3_${backupDate}_v${version}.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${backupDate}_v${version}.backup
+  loadStatus=$?
+elif [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 && -z $downloadSpecificRestoreStatus ]];then
+  echo "Loading gigadbv3_${latest}_v${version}.backup"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${latest}_v${version}.backup
   loadStatus=$?
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"

--- a/gigadb/app/tools/files-url-updater/reset_database.sh
+++ b/gigadb/app/tools/files-url-updater/reset_database.sh
@@ -18,18 +18,29 @@ latest=$(date --date="1 days ago" +"%Y%m%d")
 twoDaysAgo=$(date --date="2 days ago" +"%Y%m%d")
 threeDaysAgo=$(date --date="3 days ago" +"%Y%m%d")
 thedate=${1:-$latest}
+backupDate="$1"
 
 # Default converted backup (from Ansible properties) and legacy postgres version
 defaultDB="/home/centos/database_bootstrap.backup"
 version=$(docker-compose run --rm updater psql --version | cut -d' ' -f 3 | tr -d '\n\r' )
 
 # Run files-url-updater
-echo yes | docker-compose run --rm updater ./yii dataset-files/download-restore-backup --latest
-downloadRestoreStatus=$?
+if [[ $backupDate -eq "latest" ]];then
+  echo yes | docker-compose run --rm updater ./yii dataset-files/download-restore-backup --latest
+  downloadLatestRestoreStatus=$?
+else
+  echo yes | docker-compose run --rm updater ./yii dataset-files/download-restore-backup --date $backupDate
+  downloadSpecificRestoreStatus=$?
+fi
 
 # Convert backup using legacy postgresql client
-if [[ $downloadRestoreStatus -eq 0 ]];then
+if [[ $downloadLatestRestoreStatus -eq 0 ]];then
   docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${thedate}_v${version}.backup
+  convertStatus=$?
+fi
+
+if [[ $downloadSpecificRestoreStatus -eq 0 ]];then
+  docker-compose run --rm updater pg_dump --host=pg9_3 -p 5432  --username=gigadb  --clean --create --schema=public --no-privileges --no-tablespaces --dbname=gigadb --file=converted/gigadbv3_${backupDate}_v${version}.backup
   convertStatus=$?
 fi
 
@@ -39,12 +50,39 @@ docker-compose down -v
 # Terminate other connections to RDS instance
 export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='gigadb';"
 
-# Load the dump in RDS using native postgresql client
-if [[ $downloadRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
+# Load the latest dump in RDS using native postgresql client
+if [[ $downloadLatestRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
   echo "Loading gigadbv3_${thedate}_v${version}.backup"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
   export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${thedate}_v${version}.backup
+  loadStatus=$?
+elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
+  echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${twoDaysAgo}_v${version}.backup
+  loadStatus=$?
+elif [[ -f converted/gigadbv3_${threeDaysAgo}_v${version}.backup ]];then
+  echo "Loading gigadbv3_${threeDaysAgo}_v${version}.backup from three days ago"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${threeDaysAgo}_v${version}.backup
+  loadStatus=$?
+else
+  echo "Loading default backup /home/centos/database_bootstrap.backup"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < "$defaultDB"
+  loadStatus=$?
+fi
+
+# Load the specific dump in RDS using native postgresql client
+if [[ $downloadSpecificRestoreStatus -eq 0 && $convertStatus -eq 0 ]];then
+  echo "Loading gigadbv3_${backupDate}_v${version}.backup"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "drop database if exists $DB_PG_DATABASE"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -d postgres -h $DB_PG_HOST -p 5432 -c "create database $DB_PG_DATABASE owner $DB_PG_USER"
+  export PGPASSWORD=$DB_PG_PASSWORD; psql -U $DB_PG_USER -h $DB_PG_HOST -p 5432 < converted/gigadbv3_${backupDate}_v${version}.backup
   loadStatus=$?
 elif [[ -f converted/gigadbv3_${twoDaysAgo}_v${version}.backup ]];then
   echo "Loading gigadbv3_${twoDaysAgo}_v${version}.backup from two days ago"

--- a/ops/infrastructure/bastion_playbook.yml
+++ b/ops/infrastructure/bastion_playbook.yml
@@ -184,7 +184,7 @@
 
   tasks:
   - name: Load latest database into this environment's RDS intance
-    ansible.builtin.shell: "./reset_database.sh"
+    ansible.builtin.shell: "./reset_database.sh {{ backupDate }}"
     args:
       chdir: /home/centos/files-url-updater
       executable: /bin/bash

--- a/ops/infrastructure/inventories/hosts
+++ b/ops/infrastructure/inventories/hosts
@@ -31,3 +31,4 @@ fuw_db_database = "{{ lookup('ini', 'fuw_db_database type=properties file=ansibl
 backup_file = "{{ lookup('ini', 'backup_file type=properties file=ansible.properties') }}"
 
 reset_database_cronjob_state = "absent"
+backupDate = "latest"


### PR DESCRIPTION
As part of PR https://github.com/gigascience/gigadb-website/pull/998.

By default, reset_database.sh would restore the database to the latest state as it is the default value of new variable `backupDate`, 
```
% ansible-playbook -i ../../inventories bastion_playbook.yml 

```

Unless a date in YYYYMMDD is supplied during provisioning step, as below:

```
 % ansible-playbook -i ../../inventories bastion_playbook.yml -e "backupDate=20220201"
```

In fact, if you want to activate the regular backup and  instantiate a gigadb website from a specific date, you could:
```
% ansible-playbook -i ../../inventories bastion_playbook.yml -e "reset_database_cronjob_state=present backupDate=20220201"
```

To be remained that when the regular backup is activated, the script will only attempt to restore the `latest` backup, the default db would be restored if it failed.

Since `ftp parrot.genomics.cn` is unstable, a temporary FTP server will be used:
```
% ncftp -u $user -p $password $ftp_host
NcFTP 3.2.6 (Dec 04, 2016) by Mike Gleason (http://www.NcFTP.com/contact/).
Connecting to 13.231.178.129...                                                                                                                         
Welcome to AWS FTP service.
Logging in...                                                                                                                                           
Login successful.
Logged in to ec2-13-231-178-129.ap-northeast-1.compute.amazonaws.com.                                                                                   
ncftp / > ls
gigadbv3_20220409.backup      gigadbv3_20220410.backup      gigadbv3_20220411.backup      test.txt
ncftp / > 